### PR TITLE
Fix Java client link in synapser.rmd vignette

### DIFF
--- a/vignettes/synapser.Rmd
+++ b/vignettes/synapser.Rmd
@@ -16,7 +16,7 @@ The `synapser` package provides an interface to [Synapse](<http://www.synapse.or
 * fine grained access control
 * provenance tracking
 
-The `synapser` package lets you communicate with the Synapse platform to create collaborative data analysis projects and access data using the R programming language. Other Synapse clients exist for [Python](http://docs.synapse.org/python), [Java](https://github.com/Sage-Bionetworks/Synapse-Repository-Services/tree/develop/client/synapseJavaClient>), and [the web browser](https://www.synapse.org).
+The `synapser` package lets you communicate with the Synapse platform to create collaborative data analysis projects and access data using the R programming language. Other Synapse clients exist for [Python](http://docs.synapse.org/python), [Java](https://github.com/Sage-Bionetworks/Synapse-Repository-Services/tree/develop/client/synapseJavaClient), and [the web browser](https://www.synapse.org).
 
 If you're just getting started with Synapse, have a look at the [Getting Started guides for Synapse](http://docs.synapse.org/articles/getting_started.html).
 


### PR DESCRIPTION
An extraneous `>` broke the link.