### PR TITLE
Use consistent style in .R files

### DIFF
--- a/R/shared.R
+++ b/R/shared.R
@@ -1,17 +1,24 @@
 # Utilities for getting Python method signatures and documentation
-# 
+#
 # Author: bhoff
 ###############################################################################
 
 .addSynPrefix <- function(name) {
-  paste("syn", toupper(substring(name, 1, 1)), substring(name, 2, nchar(name)), sep = "")
+  paste(
+    "syn",
+    toupper(substring(name, 1, 1)),
+    substring(name, 2, nchar(name)),
+    sep = ""
+  )
 }
 
 .addPythonAndFoldersToSysPath <- function(srcDir) {
   pyImport("sys")
   pyExec(sprintf("sys.path.append('%s')", file.path(srcDir, "python")))
   pyImport("installPythonClient")
-  pyExec(sprintf("installPythonClient.addLocalSitePackageToPythonPath('%s')", srcDir))
+  pyExec(
+    sprintf("installPythonClient.addLocalSitePackageToPythonPath('%s')", srcDir)
+  )
 }
 
 # for each function in the Python 'Synapse' class, get:
@@ -31,7 +38,9 @@
 
   # the now add the prefix 'syn'
   result <- lapply(X = pyFunctionInfo, function(x) {
-    if (!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) return(NULL)
+    if (!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) {
+      return(NULL)
+    }
     if (x$module == "synapseclient.client") {
       synName <- .addSynPrefix(x$name)
       functionContainerName <- "syn" # function is contained in an instance of the Synapse class
@@ -41,7 +50,14 @@
     } else {
       stop(sprintf("Unexpected module %s for %s", x$module, x$name))
     }
-    list(name = x$name, synName = synName, functionContainerName = functionContainerName, args = x$args, doc = x$doc, title = synName)
+    list(
+      name = x$name,
+      synName = synName,
+      functionContainerName = functionContainerName,
+      args = x$args,
+      doc = x$doc,
+      title = synName
+    )
   })
   # scrub the nulls
   result[-which(sapply(result, is.null))]
@@ -49,15 +65,25 @@
 
 .removeOmittedClassesAndMethods <- function(pyClassInfo) {
   classesToSkip <- c("Entity")
-  methodsToOmit <- c("postURI", "getURI", "putURI", "deleteURI", "getACLURI", "putACLURI", "keys", "has_key")
+  methodsToOmit <- c(
+    "postURI",
+    "getURI",
+    "putURI",
+    "deleteURI",
+    "getACLURI",
+    "putACLURI",
+    "keys",
+    "has_key"
+  )
   result <- lapply(X = pyClassInfo, function(x) {
     if (any(x$name == classesToSkip)) return(NULL)
     if (!is.null(x$methods)) {
-      culledMethods <- lapply(X = x$methods,
-                              function(x) {
-                                if (any(x$name == methodsToOmit)) NULL else x;
-                                }
-                              )
+      culledMethods <- lapply(
+        X = x$methods,
+        function(x) {
+          if (any(x$name == methodsToOmit)) NULL else x
+        }
+      )
       # Now remove the nulls
       nullIndices <- sapply(culledMethods, is.null)
       if (any(nullIndices)) {

--- a/R/table.R
+++ b/R/table.R
@@ -1,5 +1,5 @@
 # Utilities for working with table in synapser
-# 
+#
 # Author: kimyen
 ###############################################################################
 
@@ -14,7 +14,10 @@
         dataFrame[[i]][is.nan(dataFrame[[i]])] <- "NaN"
       } else if (is(dataFrame[[i]], "POSIXct")) {
         # convert POSIXct before uploading to Synapse
-        dataFrame[[i]] <- format(as.POSIXlt(dataFrame[[i]], "UTC", usetz = TRUE), "%Y-%m-%d %H:%M:%S.000")
+        dataFrame[[i]] <- format(
+          as.POSIXlt(dataFrame[[i]], "UTC", usetz = TRUE),
+          "%Y-%m-%d %H:%M:%S.000"
+        )
       }
     }
   }
@@ -23,11 +26,19 @@
 
 # reading a csv file and returning a data.frame
 .readCsv <- function(filePath) {
-  tryCatch({
-    read.csv(filePath, encoding = "UTF-8", stringsAsFactors = FALSE, check.names = FALSE, na.strings = c(""))
-  },
-  error = function(e) {
-    stopifnot(e$message == "first five rows are empty: giving up")
-    data.frame()
-  })
+  tryCatch(
+    {
+      read.csv(
+        filePath,
+        encoding = "UTF-8",
+        stringsAsFactors = FALSE,
+        check.names = FALSE,
+        na.strings = c("")
+      )
+    },
+    error = function(e) {
+      stopifnot(e$message == "first five rows are empty: giving up")
+      data.frame()
+    }
+  )
 }

--- a/tests/testthat/test_cleanUpStackTrace.R
+++ b/tests/testthat/test_cleanUpStackTrace.R
@@ -1,51 +1,63 @@
 context("test cleanUpStackTrace")
 
-createErrorNonWin<-function(x) {
-	cat(sprintf("exception-message-boundaryEncountered an error %s\nexception-message-boundary", x))
-	stop("irrelevant text")
+createErrorNonWin <- function(x) {
+  cat(
+    sprintf(
+      "exception-message-boundaryEncountered an error %s\nexception-message-boundary",
+      x
+    )
+  )
+  stop("irrelevant text")
 }
 
 test_that("cleanUpStackTrace NonWin", {
-	tryCatch(
-		{
-			.cleanUpStackTrace(createErrorNonWin, list(x=123))
-			fail("Error expected")
-		},
-		error=function(e) {
-			expect_equal(e[[1]], "Encountered an error 123\n")
-		}
-	)
+  tryCatch(
+    {
+      .cleanUpStackTrace(createErrorNonWin, list(x = 123))
+      fail("Error expected")
+    },
+    error = function(e) {
+      expect_equal(e[[1]], "Encountered an error 123\n")
+    }
+  )
 })
 
 # On Windows the error goes into the error message rather than to stdout
-createErrorWin<-function(x) {
-	cat("irrelevant text")
-	stop(sprintf("exception-message-boundaryEncountered an error %s\nexception-message-boundary", x))
+createErrorWin <- function(x) {
+  cat("irrelevant text")
+  stop(
+    sprintf(
+      "exception-message-boundaryEncountered an error %s\nexception-message-boundary",
+      x
+    )
+  )
 }
 
 
 test_that("cleanUpStackTrace", {
-	tryCatch(
-		{
-			.cleanUpStackTrace(createErrorWin, list(x=123))
-			fail("Error expected")
-		},
-		error=function(e) {
-			expect_equal(e[[1]], "Encountered an error 123\n")
-		}
-	)
+  tryCatch(
+    {
+      .cleanUpStackTrace(createErrorWin, list(x = 123))
+      fail("Error expected")
+    },
+    error = function(e) {
+      expect_equal(e[[1]], "Encountered an error 123\n")
+    }
+  )
 })
 
 test_that("multiple parallel calls work", {
-	conn<-textConnection("outputCapture", open="w")
-	writeLines("this is a test", conn)
+  conn <- textConnection("outputCapture", open = "w")
+  writeLines("this is a test", conn)
 
-	tryCatch(
-		{
-			.cleanUpStackTrace(function(x){x}, list(x=123))
-		},
-		finally = {
-			close(conn)
-		}
-	)
+  tryCatch(
+    {
+      .cleanUpStackTrace(function(x) {
+        x
+      }, list(x = 123))
+    },
+    finally = {
+      close(conn)
+    }
+  )
 })

--- a/tests/testthat/test_createRdFiles.R
+++ b/tests/testthat/test_createRdFiles.R
@@ -1,5 +1,5 @@
 # This script runs all the markdown files and tests that they do not fail
-# 
+#
 # Author: bhoff
 ###############################################################################
 
@@ -9,156 +9,154 @@ require(synapser)
 
 context("test_createRdFiles")
 
-sourceRootDir<-"../.."
+sourceRootDir <- "../.."
 source(file.path(sourceRootDir, "tools/createRdFiles.R"))
 
 initAutoGenerateRdFiles(sourceRootDir)
 
-rawString<-":param modified_time: float representing seconds since unix epoch"
-expected<-"\nmodified_time: float representing seconds since unix epoch"
+rawString <- ":param modified_time: float representing seconds since unix epoch"
+expected <- "\nmodified_time: float representing seconds since unix epoch"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
 
-rawString<-":parameter bitFlags: Bit flags representing which entity components to return"
-expected<-"\nbitFlags: Bit flags representing which entity components to return"
+rawString <- ":parameter bitFlags: Bit flags representing which entity components to return"
+expected <- "\nbitFlags: Bit flags representing which entity components to return"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-":parameter team: A :py:class:`Team` object or a team's ID."
-expected<-"\nteam: A Team object or a team's ID."
+rawString <- ":parameter team: A :py:class:`Team` object or a team's ID."
+expected <- "\nteam: A Team object or a team's ID."
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-":var id:              An immutable ID issued by the platform"
-expected<-"\nid:              An immutable ID issued by the platform"
+rawString <- ":var id:              An immutable ID issued by the platform"
+expected <- "\nid:              An immutable ID issued by the platform"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"An updated :py:class:`synapseclient.activity.Activity` object"
-expected<-"An updated Activity object"
+rawString <- "An updated :py:class:`synapseclient.activity.Activity` object"
+expected <- "An updated Activity object"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"Once that's done, you'll be able to load the library, create a :py:class:`Synapse` object and login"
-expected<-"Once that's done, you'll be able to load the library, create a Synapse object and login"
+rawString <- "Once that's done, you'll be able to load the library, create a :py:class:`Synapse` object and login"
+expected <- "Once that's done, you'll be able to load the library, create a Synapse object and login"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"See also: :py:func:`synapseclient.Synapse.chunkedQuery`"
-expected<-"See also: synChunkedQuery"
+rawString <- "See also: :py:func:`synapseclient.Synapse.chunkedQuery`"
+expected <- "See also: synChunkedQuery"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"- :py:func:`Synapse.login`"
-expected<-"- synLogin"
+rawString <- "- :py:func:`Synapse.login`"
+expected <- "- synLogin"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"See also: :py:func:`synapseclient.Synapse.chunkedQuery` ... More robust than :py:func:`synapseclient.Synapse.query`"
-expected<-"See also: synChunkedQuery ... More robust than synQuery"
+rawString <- "See also: :py:func:`synapseclient.Synapse.chunkedQuery` ... More robust than :py:func:`synapseclient.Synapse.query`"
+expected <- "See also: synChunkedQuery ... More robust than synQuery"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"See: :py:mod:`synapseclient.table.Column`"
-expected<-"See: Column"
+rawString <- "See: :py:mod:`synapseclient.table.Column`"
+expected <- "See: Column"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-":py:meth:`synapseclient.Synapse.store`."
-expected<-"synStore."
+rawString <- ":py:meth:`synapseclient.Synapse.store`."
+expected <- "synStore."
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"foo dict() -> new empty dictionary\ndict(mapping) -> new dictionary initialized from a mapping object's\n    (key, value) pairs\ndict(iterable) -> new dictionary initialized as if via:\n    d = {}\n    for k, v in iterable:\n        d[k] = v\ndict(**kwargs) -> new dictionary initialized with the name=value pairs\n    in the keyword argument list.  For example:  dict(one=1, two=2) bar"
-expected<-"foo \nConstructor accepts named arguments.\n bar"
-dictDocString<-getDictDocString(sourceRootDir)	
+rawString <- "foo dict() -> new empty dictionary\ndict(mapping) -> new dictionary initialized from a mapping object's\n    (key, value) pairs\ndict(iterable) -> new dictionary initialized as if via:\n    d = {}\n    for k, v in iterable:\n        d[k] = v\ndict(**kwargs) -> new dictionary initialized with the name=value pairs\n    in the keyword argument list.  For example:  dict(one=1, two=2) bar"
+expected <- "foo \nConstructor accepts named arguments.\n bar"
+dictDocString <- getDictDocString(sourceRootDir)
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-"some junk:parameter bitFlags: Bit flags representing which entity components to return\r\n\nsome trailing gobbledygook"
-expected<-list(bitFlags=" Bit flags representing which entity components to return")
+rawString <- "some junk:parameter bitFlags: Bit flags representing which entity components to return\r\n\nsome trailing gobbledygook"
+expected <- list(bitFlags = " Bit flags representing which entity components to return")
 expect_equal(parseArgDescriptionsFromDetails(rawString), expected)
 
-rawString<-":parameter foo:bar :parameter bitFlags: Bit flags representing which entity components to return\r\n\nsome trailing gobbledygook"
-expected<-list(foo="bar ", bitFlags=" Bit flags representing which entity components to return")
-actual<-parseArgDescriptionsFromDetails(rawString)
+rawString <- ":parameter foo:bar :parameter bitFlags: Bit flags representing which entity components to return\r\n\nsome trailing gobbledygook"
+expected <- list(foo = "bar ", bitFlags = " Bit flags representing which entity components to return")
+actual <- parseArgDescriptionsFromDetails(rawString)
 expect_equal(actual, expected)
 
-rawString<-":parameter foo:fooDescription:parameter bar:barDescription"
-expected<-list(foo="fooDescription", bar="barDescription")
-actual<-parseArgDescriptionsFromDetails(rawString)
+rawString <- ":parameter foo:fooDescription:parameter bar:barDescription"
+expected <- list(foo = "fooDescription", bar = "barDescription")
+actual <- parseArgDescriptionsFromDetails(rawString)
 expect_equal(actual, expected)
 
-rawString<-":parameter foo:fooDescription:parameter bar:\"barDescription\""
-expected<-list(foo="fooDescription", bar="\"barDescription\"")
-actual<-parseArgDescriptionsFromDetails(rawString)
+rawString <- ":parameter foo:fooDescription:parameter bar:\"barDescription\""
+expected <- list(foo = "fooDescription", bar = "\"barDescription\"")
+actual <- parseArgDescriptionsFromDetails(rawString)
 expect_equal(actual, expected)
 
-rawString<-":parameter foo:fooDescription:parameter bar:{barDescription}"
-expected<-list(foo="fooDescription", bar="{barDescription}")
-actual<-parseArgDescriptionsFromDetails(rawString)
+rawString <- ":parameter foo:fooDescription:parameter bar:{barDescription}"
+expected <- list(foo = "fooDescription", bar = "{barDescription}")
+actual <- parseArgDescriptionsFromDetails(rawString)
 expect_equal(actual, expected)
 
-rawString<-":parameter foo:fooDescription:parameter bar:bar\\Description"
-expected<-list(foo="fooDescription", bar="bar\\Description")
-actual<-parseArgDescriptionsFromDetails(rawString)
+rawString <- ":parameter foo:fooDescription:parameter bar:bar\\Description"
+expected <- list(foo = "fooDescription", bar = "bar\\Description")
+actual <- parseArgDescriptionsFromDetails(rawString)
 expect_equal(actual, expected)
 
-rawString<-":parameter team: A :py:class:`Team` object or a team's ID.\n:returns: a generator over :py:class:`TeamMember` objects."
-expected<-list(team=" A Team object or a team's ID.")
-actual<-parseArgDescriptionsFromDetails(rawString)
-expect_equal(actual, expected, info=toJSON(actual))
+rawString <- ":parameter team: A :py:class:`Team` object or a team's ID.\n:returns: a generator over :py:class:`TeamMember` objects."
+expected <- list(team = " A Team object or a team's ID.")
+actual <- parseArgDescriptionsFromDetails(rawString)
+expect_equal(actual, expected, info = toJSON(actual))
 
-rawString<-"`reference objects <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Reference.html>`_"
-expected<-"\\href{http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Reference.html}{reference objects}"
+rawString <- "`reference objects <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Reference.html>`_"
+expected <- "\\href{http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Reference.html}{reference objects}"
 expect_equal(changeSphinxHyperlinksToLatex(rawString), expected)
 
-rawString<-"may involve some loss of information. See :py:func:`_getRawAnnotations` to get"
-expected<-"may involve some loss of information. See _getRawAnnotations to get"
+rawString <- "may involve some loss of information. See :py:func:`_getRawAnnotations` to get"
+expected <- "may involve some loss of information. See _getRawAnnotations to get"
 expect_equal(pyVerbiageToLatex(rawString), expected)
 
-rawString<-":returns:This is the returned value.\n\nand not this"
-expected<-"This is the returned value."
+rawString <- ":returns:This is the returned value.\n\nand not this"
+expected <- "This is the returned value."
 expect_equal(getReturned(rawString), expected)
 
-rawString<-":return:This is the returned value.\r\n\nand not this"
-expected<-"This is the returned value."
+rawString <- ":return:This is the returned value.\r\n\nand not this"
+expected <- "This is the returned value."
 expect_equal(getReturned(rawString), expected)
 
-rawString<-":return:This is the returned value.\r\n\nand not this\n\nor this"
-expected<-"This is the returned value."
+rawString <- ":return:This is the returned value.\r\n\nand not this\n\nor this"
+expected <- "This is the returned value."
 expect_equal(getReturned(rawString), expected)
 
-rawString<-"Get the permissions that a user or group has on an Entity.\n\n:param entity:      An Entity or Synapse ID to lookup\n:param principalId: Identifier of a user or group (defaults to PUBLIC users)\n\n:returns: An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array\n\n"
-expected<-" An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array"
+rawString <- "Get the permissions that a user or group has on an Entity.\n\n:param entity:      An Entity or Synapse ID to lookup\n:param principalId: Identifier of a user or group (defaults to PUBLIC users)\n\n:returns: An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array\n\n"
+expected <- " An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array"
 expect_equal(getReturned(rawString), expected)
 
-rawString<-"Represents the provenance of a Synapse Entity.\n\r\n:param name:        name of the Activity\n:param description: a short text description of the Activity"
-expected<-"Represents the provenance of a Synapse Entity."
+rawString <- "Represents the provenance of a Synapse Entity.\n\r\n:param name:        name of the Activity\n:param description: a short text description of the Activity"
+expected <- "Represents the provenance of a Synapse Entity."
 expect_equal(getDescription(rawString), expected)
 
-rawString<-"Get the permissions that a user or group has on an Entity.\n\n:param entity:      An Entity or Synapse ID to lookup\n:param principalId: Identifier of a user or group (defaults to PUBLIC users)\n\n:returns: An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array\n\n"
-expected<-"Get the permissions that a user or group has on an Entity."
+rawString <- "Get the permissions that a user or group has on an Entity.\n\n:param entity:      An Entity or Synapse ID to lookup\n:param principalId: Identifier of a user or group (defaults to PUBLIC users)\n\n:returns: An array containing some combination of\n\t\t['READ', 'CREATE', 'UPDATE', 'DELETE', 'CHANGE_PERMISSIONS', 'DOWNLOAD', 'PARTICIPATE']\n\t\t or an empty array\n\n"
+expected <- "Get the permissions that a user or group has on an Entity."
 expect_equal(getDescription(rawString), expected)
 
-rawString<-"Represent a `Synapse Team <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html>`_\nUser definable fields are:\n:param icon:          fileHandleId for icon image of the Team"
-expected<-"Represent a `Synapse Team <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html>`_\nUser definable fields are:"
-actual<-getDescription(rawString)
+rawString <- "Represent a `Synapse Team <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html>`_\nUser definable fields are:\n:param icon:          fileHandleId for icon image of the Team"
+expected <- "Represent a `Synapse Team <http://docs.synapse.org/rest/org/sagebionetworks/repo/model/Team.html>`_\nUser definable fields are:"
+actual <- getDescription(rawString)
 expect_equal(actual, expected)
 
 # if there is no description, should return nothing
-rawString<-":param wiki: the Wiki object for which ...\n:return: a list of ..."
-expected<-""
-actual<-getDescription(rawString)
+rawString <- ":param wiki: the Wiki object for which ...\n:return: a list of ..."
+expected <- ""
+actual <- getDescription(rawString)
 expect_equal(actual, expected)
 
 # if there is just one line, return it
-rawString<-"Is the given key a property or annotation?"
-expected<-"Is the given key a property or annotation?"
-actual<-getDescription(rawString)
+rawString <- "Is the given key a property or annotation?"
+expected <- "Is the given key a property or annotation?"
+actual <- getDescription(rawString)
 expect_equal(actual, expected)
 
 
-rawString<-"Convenience method to create a Synapse object and login.\r\n\nSee :py:func:`synapseclient.Synapse.login` for arguments and usage.\n\nExample::\n\n\timport synapseclient\n\tsyn = synapseclient.login()"
-expected<-"\timport synapseclient\n\tsyn = synapseclient.login()"
+rawString <- "Convenience method to create a Synapse object and login.\r\n\nSee :py:func:`synapseclient.Synapse.login` for arguments and usage.\n\nExample::\n\n\timport synapseclient\n\tsyn = synapseclient.login()"
+expected <- "\timport synapseclient\n\tsyn = synapseclient.login()"
 expect_equal(getExample(rawString), expected)
 
-rawString<-"Convenience method to create a Synapse object and login.\r\n\nSee :py:func:`synapseclient.Synapse.login` for arguments and usage.\n\nExample::\n\n\timport synapseclient\n\tsyn = synapseclient.login()\n\nsome more content"
-expected<-"\timport synapseclient\n\tsyn = synapseclient.login()"
-expect_equal(getExample(rawString), expected)
-
-
-rawString<-"\nGets an Evaluation object from Synapse.\n\nSee: :py:mod:`synapseclient.evaluation`\n\nExample::\n\n\tevaluation = syn.getEvalutation(2005090)"
-expected<-"\tevaluation = syn.getEvalutation(2005090)"
+rawString <- "Convenience method to create a Synapse object and login.\r\n\nSee :py:func:`synapseclient.Synapse.login` for arguments and usage.\n\nExample::\n\n\timport synapseclient\n\tsyn = synapseclient.login()\n\nsome more content"
+expected <- "\timport synapseclient\n\tsyn = synapseclient.login()"
 expect_equal(getExample(rawString), expected)
 
 
+rawString <- "\nGets an Evaluation object from Synapse.\n\nSee: :py:mod:`synapseclient.evaluation`\n\nExample::\n\n\tevaluation = syn.getEvalutation(2005090)"
+expected <- "\tevaluation = syn.getEvalutation(2005090)"
+expect_equal(getExample(rawString), expected)

--- a/tests/testthat/test_determineArgsAndKwArgs.R
+++ b/tests/testthat/test_determineArgsAndKwArgs.R
@@ -2,35 +2,56 @@ context("test .determineArgsAndKwArgs")
 
 
 test_that("no arguments", {
-	expect_equal(.determineArgsAndKwArgs(), list(args=list(), kwargs=list()))
+  expect_equal(
+    .determineArgsAndKwArgs(),
+    list(args = list(), kwargs = list())
+  )
 })
 
 test_that("unnamed arguments", {
-	expect_equal(.determineArgsAndKwArgs("foo", "bar"), list(args=list("foo", "bar"), kwargs=list()))
+  expect_equal(
+    .determineArgsAndKwArgs("foo", "bar"),
+    list(args = list("foo", "bar"), kwargs = list())
+  )
 })
 
 test_that("unnamed arguments, followed by named argument", {
-	expect_equal(.determineArgsAndKwArgs("foo", "bar", x="baz"), list(args=list("foo", "bar"), kwargs=list(x="baz")))
+  expect_equal(
+    .determineArgsAndKwArgs("foo", "bar", x = "baz"),
+    list(args = list("foo", "bar"), kwargs = list(x = "baz"))
+  )
 })
 
 test_that("only named argument", {
-	expect_equal(.determineArgsAndKwArgs(a="foo", b="bar", c="baz"), list(args=list(), kwargs=list(a="foo", b="bar", c="baz")))
+  expect_equal(
+    .determineArgsAndKwArgs(a = "foo", b = "bar", c = "baz"),
+    list(args = list(), kwargs = list(a = "foo", b = "bar", c = "baz"))
+  )
 })
 
 test_that("unnamed NULL argument", {
-	expect_equal(.determineArgsAndKwArgs(NULL), list(args=list(NULL), kwargs=list()))
+  expect_equal(
+    .determineArgsAndKwArgs(NULL),
+    list(args = list(NULL), kwargs = list())
+  )
 })
 
 test_that("unnamed arguments with NULL", {
-	expect_equal(.determineArgsAndKwArgs("foo", NULL), list(args=list("foo", NULL), kwargs=list()))
+  expect_equal(
+    .determineArgsAndKwArgs("foo", NULL),
+    list(args = list("foo", NULL), kwargs = list())
+  )
 })
 
 test_that("named arguments with NULL", {
-	expect_equal(.determineArgsAndKwArgs(a="foo", b=NULL, c="baz"), list(args=list(), kwargs=list(a="foo", b=NULL, c="baz")))
+  expect_equal(
+    .determineArgsAndKwArgs(a = "foo", b = NULL, c = "baz"),
+    list(args = list(), kwargs = list(a = "foo", b = NULL, c = "baz"))
+  )
 })
 
 test_that("unnamed arguments after named ones trigger an error", {
-	expect_error(.determineArgsAndKwArgs(foo="bar", "baz"))
+  expect_error(
+    .determineArgsAndKwArgs(foo = "bar", "baz")
+  )
 })
-
-

--- a/tests/testthat/test_getSynapseClassInfo.R
+++ b/tests/testthat/test_getSynapseClassInfo.R
@@ -1,37 +1,137 @@
 context("test getSynapseClassInfo")
 
-name1Methods <- list(list(name="n1m1", doc="doc", args=list()), list(name="n1m2", doc="doc", args=list()))
-name2Methods <- list(list(name="n1m1", doc="doc", args=list()), list(name="n1m2", doc="doc", args=list()))
-name3Methods <- list(list(name="n1m1", doc="doc", args=list()), list(name="n1m2", doc="doc", args=list()))
+name1Methods <- list(
+  list(name = "n1m1", doc = "doc", args = list()),
+  list(name = "n1m2", doc = "doc", args = list())
+)
+name2Methods <- list(
+  list(name = "n1m1", doc = "doc", args = list()),
+  list(name = "n1m2", doc = "doc", args = list())
+)
+name3Methods <- list(
+  list(name = "n1m1", doc = "doc", args = list()),
+  list(name = "n1m2", doc = "doc", args = list())
+)
 
 test_that(".removeOmittedClassesAndMethods happy case works", {
-	class1<-list(name="name1", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name1Methods)
-	class2<-list(name="name2", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name2Methods)
-	class3<-list(name="name3", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name3Methods)
-	simple<-list(class1, class2, class3)
-	result<-.removeOmittedClassesAndMethods(simple)
-	expect_equal(result, simple)
+  class1 <- list(
+    name = "name1",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name1Methods
+  )
+  class2 <- list(
+    name = "name2",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name2Methods
+  )
+  class3 <- list(
+    name = "name3",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name3Methods
+  )
+  simple <- list(class1, class2, class3)
+  result <- .removeOmittedClassesAndMethods(simple)
+  expect_equal(result, simple)
 })
 
 test_that(".removeOmittedClassesAndMethods omits Entity class", {
-	class1<-list(name="name1", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name1Methods)
-	entityClass<-list(name="Entity", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name2Methods)
-	class3<-list(name="name3", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name3Methods)
-	classToOmit<-list(class1, entityClass, class3)
-	result<-.removeOmittedClassesAndMethods(classToOmit)
-	expect_equal(result, list(class1, class3))
+  class1 <- list(
+    name = "name1",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name1Methods
+  )
+  entityClass <- list(
+    name = "Entity",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name2Methods
+  )
+  class3 <- list(
+    name = "name3",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name3Methods
+  )
+  classToOmit <- list(class1, entityClass, class3)
+  result <- .removeOmittedClassesAndMethods(classToOmit)
+  expect_equal(result, list(class1, class3))
 })
 
 test_that(".removeOmittedClassesAndMethods omits Entity class", {
-	class1<-list(name="name1", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=name1Methods)
-	withMethodToOmit<-list(list(name="n1m1", doc="doc", args=list()), list(name="postURI", doc="doc", args=list()))
-	class2<-list(name="name3", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=withMethodToOmit)
-	classes<-list(class1, class2)
-	result<-.removeOmittedClassesAndMethods(classes)
-	withMethodOmitted<-list(list(name="n1m1", doc="doc", args=list()))
-	class2WithMethodOmitted<-list(name="name3", constructorArgs=list(args=list("arg1"), varargs=list("varargs1"), keywords=list(), defaults=list()), doc="doc", methods=withMethodOmitted)
-	expected<-list(class1, class2WithMethodOmitted)
-	expect_equal(result, expected)
+  class1 <- list(
+    name = "name1",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = name1Methods
+  )
+  withMethodToOmit <- list(
+    list(name = "n1m1", doc = "doc", args = list()),
+    list(name = "postURI", doc = "doc", args = list())
+  )
+  class2 <- list(
+    name = "name3",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = withMethodToOmit
+  )
+  classes <- list(class1, class2)
+  result <- .removeOmittedClassesAndMethods(classes)
+  withMethodOmitted <- list(list(name = "n1m1", doc = "doc", args = list()))
+  class2WithMethodOmitted <- list(
+    name = "name3",
+    constructorArgs = list(
+      args = list("arg1"),
+      varargs = list("varargs1"),
+      keywords = list(),
+      defaults = list()
+    ),
+    doc = "doc",
+    methods = withMethodOmitted
+  )
+  expected <- list(class1, class2WithMethodOmitted)
+  expect_equal(result, expected)
 })
-
-

--- a/tests/testthat/test_outputSideeffect.R
+++ b/tests/testthat/test_outputSideeffect.R
@@ -2,14 +2,10 @@ context("test .outputSideeffect")
 
 
 test_that("no output as a side effect", {
-	conn<-textConnection("stdoutContent", open="w")
-	sink(conn)
-	file<-Folder(parentId="syn123456")
-	sink()
-	close(conn)
-	expect_equal(length(stdoutContent), 0)
+  conn <- textConnection("stdoutContent", open = "w")
+  sink(conn)
+  file <- Folder(parentId = "syn123456")
+  sink()
+  close(conn)
+  expect_equal(length(stdoutContent), 0)
 })
-
-
-
-


### PR DESCRIPTION
Per discussion with @kimyen I've updated the code style to follow the [tidyverse style guidelines](http://style.tidyverse.org/). I ran `styler::style_file()` on each file and manually wrapped some long lines that styler didn't modify. Happy to squash these into a single commit if that's preferable.