### PR TITLE
Document how to store updates to a subset of annotations in a view

### DIFF
--- a/vignettes/views.Rmd
+++ b/vignettes/views.Rmd
@@ -94,7 +94,7 @@ The change in annotations is reflected in synGetAnnotations():
 synGetAnnotations(file2$properties$id)
 ```
 
-A unique etag is associated with every file that updates when changes are made to the file annotations or metadata. Any updates pushed to Synapse will change an object's etag.
+A unique etag is associated with every file that updates when changes are made to a file, including the contents, annotations, or metadata. Any updates pushed to Synapse will change an object's etag.
 ```{r collapse=TRUE, eval=FALSE}
 data$etag
 ```

--- a/vignettes/views.Rmd
+++ b/vignettes/views.Rmd
@@ -89,7 +89,7 @@ data["class"] <- c("V", "VI")
 synStore(Table(view$properties$id, data))
 ```
 
-The change in annotations reflect in synGetAnnotations():
+The change in annotations is reflected in synGetAnnotations():
 ```{r collapse=TRUE, eval=FALSE}
 synGetAnnotations(file2$properties$id)
 ```

--- a/vignettes/views.Rmd
+++ b/vignettes/views.Rmd
@@ -102,7 +102,7 @@ data$etag
 There may be cases where you want to update the annotations on a subset of files in a view. In order to preserve the etag, and thus the file history, you will need to store only the rows that have been modified. 
 ```{r collapse=TRUE}
 data$contributor[1] <- c("Sage Bionetworks")
-synStore(Table(view$properties$id ,data[1,]))
+synStore(Table(view$properties$id, data[1,]))
 ```
 
 ## Update View's Content

--- a/vignettes/views.Rmd
+++ b/vignettes/views.Rmd
@@ -94,6 +94,17 @@ The change in annotations is reflected in synGetAnnotations():
 synGetAnnotations(file2$properties$id)
 ```
 
+A unique etag is associated with every file that updates when changes are made to the file annotations or metadata. Any updates pushed to Synapse will change an object's etag.
+```{r collapse=TRUE, eval=FALSE}
+data$etag
+```
+
+There may be cases where you want to update the annotations on a subset of files in a view. In order to preserve the etag, and thus the file history, you will need to store only the rows that have been modified. 
+```{r collapse=TRUE}
+data$contributor[1] <- c("Sage Bionetworks")
+synStore(Table(view$properties$id ,data[1,]))
+```
+
 ## Update View's Content
 
 A view can contain different types of entity. To change the types of entity that will show up in a view:


### PR DESCRIPTION
This is to prevent the case where file metadata (modifiedOn) is updated in a non-specific way as etag updates are impartial to actual changes to a Table, rather the etag updates with any `synStore()` operation. Complete discussion in [JIRA PLFM-5870](https://sagebionetworks.jira.com/browse/PLFM-5870).