### PR TITLE
SYNR-1233 Silence check for update

### DIFF
--- a/R/version_check.R
+++ b/R/version_check.R
@@ -45,7 +45,7 @@
 .checkForUpdate <- function(package = "synapser",
                             ran = "http://ran.synapse.org",
                             precision = 2) {
-  info <- old.packages(repos = ran)
+  info <- suppressWarnings(old.packages(repos = ran))
   if (.isVersionOutOfDate(info, package, packageVersion(package), precision)) {
     .printVersionOutOfDateWarnings(info[package, "Installed"], info[package, "ReposVer"], package, ran)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,6 @@
   PythonEmbedInR::pyExec("synapseclient.USER_AGENT['User-Agent'] = synapserVersion + synapseclient.USER_AGENT['User-Agent']")
   PythonEmbedInR::pyExec("synapseclient.config.single_threaded = True")
   PythonEmbedInR::pyExec("syn=synapseclient.Synapse(skip_checks=True)")
-  .checkForUpdate()
 
   # register interrupt check
   libraryName <- sprintf("PythonEmbedInR%s", .Platform$dynlib.ext)
@@ -91,6 +90,7 @@
   3) Use and contribute only data de-identified to HIPAA standards.
   4) Redistribute data only under these same terms of use.\n"
 
+  .checkForUpdate()
   packageStartupMessage(tou)
 }
 

--- a/tests/testthat/test_version_check.R
+++ b/tests/testthat/test_version_check.R
@@ -65,3 +65,11 @@ test_that(".isVersionOutOfDate() handles edge case in string comparison", {
 test_that(".checkForUpdate() does not fail when synapser does not available", {
   expect_equal(NULL, .checkForUpdate(ran = "https://cran.r-project.org/"))
 })
+
+test_that(".checkForUpdate does not warn when can't access repo", {
+  # If repo is inaccessible for whatever reason, .checkForUpdate() should
+  # silently return NULL. This prevents warning messages from appearing when
+  # loading synapser without an internet connection.
+  expect_silent(.checkForUpdate(ran = ""))
+  expect_null(.checkForUpdate(ran = ""))
+})


### PR DESCRIPTION
* Moves `.checkForUpdate()` to `.onAttach()` so it is run when the package is attached, e.g. with `library()` or `require()`, but not when it is merely loaded via `::`, `requireNamespace()` or `loadNamespace()`.
* Suppresses warnings when comparing package versions to an external repository, so that attaching the package without an internet connection doesn't cause a warning.
