### PR TITLE
SYNR-1458 Use R_HOME in configure script to invoke the proper R installation

### DIFF
--- a/configure
+++ b/configure
@@ -2,6 +2,13 @@
 
 ./cleanup
 
+# where R_HOME is available prepend it to the path to ensure
+# that we are using the version of R used to install this package
+# for the R commands within this script.
+if [ -d "$R_HOME/bin" ]; then
+    PATH="$R_HOME/bin:$PATH"
+fi
+
 echo "library('PythonEmbedInR')" > testPip.R
 echo "pyExec('import pip')" >> testPip.R
 R --slave < testPip.R


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SYNR-1458

Our synapser configure script itself invokes R and RScript expecting them to be available from the PATH. However if R is installed somewhere that isn't on the path or there are multiple R installations on the system it may not find the proper R version, despite this being invoked downstream of an executing R session.

An executing R session should set the [R_HOME](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Rhome.html) environment variable indicating the path to the running R version. If it is available and has a bin directory, this prepends it to the path ensuring that the R and RScript calls will use the expected version of R.