### PR TITLE
Document how to use synapser if you use google to sign in

### DIFF
--- a/vignettes/manageSynapseCredentials.Rmd
+++ b/vignettes/manageSynapseCredentials.Rmd
@@ -32,7 +32,7 @@ apikey = your_apikey
 
 ```
 
-You can choose to specify either `username` and `password` or `username` and `apikey`. For security purposes, we recommend that you use Synapse apikey instead of your password.
+You can choose to specify either `username` and `password` or `username` and `apikey`. For security purposes, we recommend that you use Synapse apikey instead of your password. Your API key can be found by logging in to Synapse and navigating to the bottom of the Settings page.
 
 Then login without specifying your username and password:
 ```

--- a/vignettes/synapser.Rmd
+++ b/vignettes/synapser.Rmd
@@ -48,10 +48,12 @@ Please see the [Troubleshooting](troubleshooting.html) vignettes for more inform
 ## Connecting to Synapse
 
 To use Synapse, you'll need to
-[register](https://www.synapse.org/#!RegisterAccount:0)
-for an account. The Synapse website can authenticate using a Google account,
-but you'll need to take the extra step of creating a Synapse password
-to use the programmatic clients.
+[register](https://www.synapse.org/#!RegisterAccount:0) for an account. The
+Synapse website can authenticate using a Google account. If you authenticate
+using a Google account, you'll need to use your API key (not a password) to log
+in to Synapse through the programmatic clients. See the 
+[Manage Synapse Credentials vignette](manageSynapseCredentials.html) for more
+information.
 
 Once that's done, you'll be able to load the library and login:
 ```{r collapse=TRUE}


### PR DESCRIPTION
This came up in a workshop today -- a user who logs in to synapse with their google account couldn't figure out how to log in with synapser. The easiest way to do this is to use their API key, but this wasn't mentioned in the documentation. I propose we document this, and also give instructions on how to find one's API key.