### PR TITLE
SYNR-1474 expose underscore functions

### DIFF
--- a/R/shared.R
+++ b/R/shared.R
@@ -23,7 +23,8 @@
 
 # for synapseclient.Synapse
 .synapseClassFunctionFilter <- function(x) {
-  if (!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) {
+  if ((!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) ||
+      (any(x$name == .methodsToOmit))) {
     return(NULL)
   } else {
     x
@@ -34,8 +35,23 @@
 
 .removeAllFunctionsFunctionFilter <- function(x) NULL
 
-.classesToSkip <- c("Entity", "Synapse")
-.methodsToOmit <- c("postURI", "getURI", "putURI", "deleteURI", "getACLURI", "putACLURI", "keys", "has_key")
+.classesToSkip <- c(
+  "Entity",
+  "Synapse",
+  "Annotations"
+)
+.methodsToOmit <- c(
+  "postURI",
+  "getURI",
+  "putURI",
+  "deleteURI",
+  "getACLURI",
+  "putACLURI",
+  "keys",
+  "has_key",
+  "set_annotations",
+  "get_annotations"
+)
 
 .synapseClientClassFilter <- function(x) {
   if (any(x$name == .classesToSkip)) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -120,12 +120,6 @@
     }
   )
 
-  methods::setGeneric(
-    name ="synBuildTable",
-    def = function(name, parent, values){
-      do.call("synBuild_table", args = list(name, parent, values))
-    }
-  )
   methods::setMethod(
     f = "synBuildTable",
     signature = c("ANY", "ANY", "data.frame"),

--- a/auto-man/synCreateExternalS3FileHandle.Rd
+++ b/auto-man/synCreateExternalS3FileHandle.Rd
@@ -1,0 +1,60 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synCreateExternalS3FileHandle}
+\alias{synCreateExternalS3FileHandle}
+\docType{methods}
+\title{
+synCreateExternalS3FileHandle
+}
+\description{
+Create an external S3 file handle for e.g. a file that has been uploaded directly to
+an external S3 storage location.
+}
+\usage{
+synCreateExternalS3FileHandle(bucket_name, s3_file_key, file_path, parent=NULL, storage_location_id=NULL, mimetype=NULL)
+}
+\arguments{
+\item{bucket_name}{             Name of the S3 bucket\cr
+}
+\item{s3_file_key}{             S3 key of the uploaded object\cr
+}
+\item{file_path}{               Local path of the uploaded file\cr
+}
+\item{parent}{                  Parent entity to create the file handle in, the file handle will be created\cr
+                                    in the default storage location of the parent. Mutually exclusive with\cr
+                                    storage_location_id\cr
+}
+\item{storage_location_id}{     Explicit storage location id to create the file handle in, mutually exclusive\cr
+                                    with parent\cr
+}
+\item{mimetype}{                Mimetype of the file, if known}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synCreateS3StorageLocation.Rd
+++ b/auto-man/synCreateS3StorageLocation.Rd
@@ -1,0 +1,63 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synCreateS3StorageLocation}
+\alias{synCreateS3StorageLocation}
+\docType{methods}
+\title{
+synCreateS3StorageLocation
+}
+\description{
+Create a storage location in the given parent, either in the given folder or by creating a new
+folder in that parent with the given name. This will both create a StorageLocationSetting,
+and a ProjectSetting together, optionally creating a new folder in which to locate it,
+and optionally enabling this storage location for access via STS. If enabling an existing folder for STS,
+it must be empty.
+}
+\usage{
+synCreateS3StorageLocation(parent=NULL, folder_name=NULL, folder=NULL, bucket_name=NULL, base_key=NULL, sts_enabled=FALSE)
+}
+\arguments{
+\item{parent}{              The parent in which to locate the storage location (mutually exclusive with folder)\cr
+}
+\item{folder_name}{         The name of a new folder to create (mutually exclusive with folder)\cr
+}
+\item{folder}{              The existing folder in which to create the storage location\cr
+                                (mutually exclusive with folder_name)\cr
+}
+\item{bucket_name}{         The name of an S3 bucket, if this is an external storage location,\cr
+                                if None will use Synapse S3 storage\cr
+}
+\item{base_key}{            The base key of within the bucket, None to use the bucket root,\cr
+                                only applicable if bucket_name is passed\cr
+}
+\item{sts_enabled}{         Whether this storage location should be STS enabled}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synCreateS3StorageLocation.Rd
+++ b/auto-man/synCreateS3StorageLocation.Rd
@@ -39,7 +39,7 @@ synCreateS3StorageLocation(parent=NULL, folder_name=NULL, folder=NULL, bucket_na
 % A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
 }
 \value{
-
+ a 3-tuple of the synapse Folder, a the storage location setting, and the project setting dictionaries
 }
 \references{
 % A section with references to the literature. Use \url{} or \href{}{} for web pointers.

--- a/auto-man/synCreateSnapshotVersion.Rd
+++ b/auto-man/synCreateSnapshotVersion.Rd
@@ -1,0 +1,56 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synCreateSnapshotVersion}
+\alias{synCreateSnapshotVersion}
+\docType{methods}
+\title{
+synCreateSnapshotVersion
+}
+\description{
+Create a new Table Version or a new View version.
+}
+\usage{
+synCreateSnapshotVersion(table, comment=NULL, label=NULL, activity=NULL, wait=TRUE)
+}
+\arguments{
+\item{table}{  The schema of the Table/View, or its ID.\cr
+}
+\item{comment}{  Optional snapshot comment.\cr
+}
+\item{label}{  Optional snapshot label.\cr
+}
+\item{activity}{  Optional activity ID applied to snapshot version.\cr
+}
+\item{wait}{ True if this method should return the snapshot version after waiting for any necessary\cr
+                asynchronous table updates to complete. If False this method will return return\cr
+                as soon as any updates are initiated.}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ the snapshot version number if wait=True, None if wait=False
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synGetMembershipStatus.Rd
+++ b/auto-man/synGetMembershipStatus.Rd
@@ -1,0 +1,51 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synGetMembershipStatus}
+\alias{synGetMembershipStatus}
+\docType{methods}
+\title{
+synGetMembershipStatus
+}
+\description{
+Retrieve a user's Team Membership Status bundle.
+https://docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html
+}
+\usage{
+synGetMembershipStatus(userid, team, user=NULL)
+}
+\arguments{
+\item{userid}{}
+\item{team}{ A Team object or a\cr
+             team's ID.}
+\item{user}{optional named parameter:  Synapse user ID\cr
+}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ dict of TeamMembershipStatus
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synGetStsStorageToken.Rd
+++ b/auto-man/synGetStsStorageToken.Rd
@@ -1,0 +1,59 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synGetStsStorageToken}
+\alias{synGetStsStorageToken}
+\docType{methods}
+\title{
+synGetStsStorageToken
+}
+\description{
+Get STS credentials for the given entity_id and permission, outputting it in the given format
+}
+\usage{
+synGetStsStorageToken(entity, permission, output_format=json, min_remaining_life=NULL)
+}
+\arguments{
+\item{entity}{          the entity or entity id whose credentials are being returned\cr
+}
+\item{permission}{      one of 'read_only' or 'read_write'\cr
+}
+\item{output_format}{   one of 'json', 'boto', 'shell', 'bash', 'cmd', 'powershell'\cr
+                        json: the dictionary returned from the Synapse STS API including expiration\cr
+                        boto: a dictionary compatible with a boto session (aws_access_key_id, etc)\cr
+                        shell: output commands for exporting credentials appropriate for the detected shell\cr
+                        bash: output commands for exporting credentials into a bash shell\cr
+                        cmd: output commands for exporting credentials into a windows cmd shell\cr
+                        powershell: output commands for exporting credentials into a windows powershell\cr
+}
+\item{min_remaining_life}{ the minimum allowable remaining life on a cached token to return. if a cached token\cr
+    has left than this amount of time left a fresh token will be fetched}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synGetTeamOpenInvitations.Rd
+++ b/auto-man/synGetTeamOpenInvitations.Rd
@@ -1,0 +1,48 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synGetTeamOpenInvitations}
+\alias{synGetTeamOpenInvitations}
+\docType{methods}
+\title{
+synGetTeamOpenInvitations
+}
+\description{
+Retrieve the open requests submitted to a Team
+https://docs.synapse.org/rest/GET/team/id/openInvitation.html
+}
+\usage{
+synGetTeamOpenInvitations(team)
+}
+\arguments{
+\item{team}{ A Team object or a\cr
+             team's ID.}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ generator of MembershipRequest
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synInviteToTeam.Rd
+++ b/auto-man/synInviteToTeam.Rd
@@ -1,0 +1,60 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synInviteToTeam}
+\alias{synInviteToTeam}
+\docType{methods}
+\title{
+synInviteToTeam
+}
+\description{
+Invite user to a Synapse team via Synapse username or email
+(choose one or the other)
+}
+\usage{
+synInviteToTeam(team, user=NULL, inviteeEmail=NULL, message=NULL, force=FALSE, syn=NULL)
+}
+\arguments{
+\item{team}{ A Team object or a\cr
+             team's ID.\cr
+}
+\item{user}{ Synapse username or profile id of user\cr
+}
+\item{inviteeEmail}{ Email of user\cr
+}
+\item{message}{ Additional message for the user getting invited to the\cr
+                team. Default to None.\cr
+}
+\item{force}{ If an open invitation exists for the invitee,\cr
+              the old invite will be cancelled. Default to False.}
+\item{syn}{optional named parameter:  Synapse object\cr
+}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ MembershipInvitation or None if user is already a member
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synIsCertified.Rd
+++ b/auto-man/synIsCertified.Rd
@@ -1,0 +1,46 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synIsCertified}
+\alias{synIsCertified}
+\docType{methods}
+\title{
+synIsCertified
+}
+\description{
+Determines whether a Synapse user is a certified user.
+}
+\usage{
+synIsCertified(user)
+}
+\arguments{
+\item{user}{}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ True if the Synapse user is certified
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/auto-man/synLogin.Rd
+++ b/auto-man/synLogin.Rd
@@ -16,6 +16,8 @@ Valid combinations of login() arguments:
 
 - email/username and apiKey (Base64 encoded string)
 
+- authToken
+
 - sessionToken (**DEPRECATED**)
 
 If no login arguments are provided or only username is provided, login() will attempt to log in using
@@ -26,7 +28,7 @@ If no login arguments are provided or only username is provided, login() will at
 #. cached credentials from previous `login()` where `rememberMe=True` was passed as a parameter
 }
 \usage{
-synLogin(email=NULL, password=NULL, apiKey=NULL, sessionToken=NULL, rememberMe=FALSE, silent=FALSE, forced=FALSE)
+synLogin(email=NULL, password=NULL, apiKey=NULL, sessionToken=NULL, rememberMe=FALSE, silent=FALSE, forced=FALSE, authToken=NULL)
 }
 \arguments{
 \item{email}{        Synapse user name (or an email address associated with a Synapse account)\cr
@@ -40,15 +42,12 @@ synLogin(email=NULL, password=NULL, apiKey=NULL, sessionToken=NULL, rememberMe=F
 }
 \item{rememberMe}{   Whether the authentication information should be cached in your operating system's\cr
                      credential storage.\cr
-**GNOME Keyring** (recommended) or **KWallet** is recommended to be installed for credential storage on\cr
-**Linux** systems.\cr
-If it is not installed/setup, credentials will be stored as PLAIN-TEXT file with read and write permissions for\cr
-the current user only (chmod 600).\cr
-On Windows and Mac OS, a default credentials storage exists so it will be preferred over the plain-text file.\cr
-To install GNOME Keyring on Ubuntu::}
+}
 \item{silent}{     Defaults to False.  Suppresses the "Welcome ...!" message.\cr
 }
 \item{forced}{     Defaults to False.  Bypass the credential cache if set.}
+\item{authToken}{    A bearer authorization token, e.g. a personal access token, can be used in lieu of a\cr
+                        password or apiKey}
 }
 \details{
 % A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.

--- a/auto-man/synSendMembershipInvitation.Rd
+++ b/auto-man/synSendMembershipInvitation.Rd
@@ -1,0 +1,54 @@
+%
+%  Auto-generated file, do not modify.
+%  Instead, copy this file to the man/ folder, remove this warning, and edit freely.
+%  Use Git to identify changes in this file which suggest where to change your edited copy.
+%
+\name{synSendMembershipInvitation}
+\alias{synSendMembershipInvitation}
+\docType{methods}
+\title{
+synSendMembershipInvitation
+}
+\description{
+Create a membership invitation and send an email notification
+to the invitee.
+}
+\usage{
+synSendMembershipInvitation(teamId, inviteeId=NULL, inviteeEmail=NULL, message=NULL)
+}
+\arguments{
+\item{teamId}{ Synapse teamId\cr
+}
+\item{inviteeId}{ Synapse username or profile id of user\cr
+}
+\item{inviteeEmail}{ Email of user\cr
+}
+\item{message}{ Additional message for the user getting invited to the\cr
+                team. Default to None.}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ MembershipInvitation
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% Examples of how to use the function. 
+% Examples are not only useful for documentation purposes, but also provide test code used for diagnostic checking of R code. 
+% By default, text will be displayed in the output of the help page and run by example() and by R CMD check. 
+% You can use \dontrun{} for text that should only be shown, but not run, and \dontshow{} for extra commands 
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+
+}
+
+
+

--- a/inst/python/installPythonClient.py
+++ b/inst/python/installPythonClient.py
@@ -77,7 +77,7 @@ def _find_python_interpreter():
 PYTHON_INTERPRETER = _find_python_interpreter()
 
 SYNAPSE_CLIENT_PACKAGE_NAME = 'synapseclient'
-SYNAPSE_CLIENT_PACKAGE_VERSION = '2.2.2'
+SYNAPSE_CLIENT_PACKAGE_VERSION = '2.3.1'
 
 JINJA_VERSION = '2.11.2'
 MARKUPSAFE_VERSION = '1.1.1'

--- a/man/synCreateExternalS3FileHandle.Rd
+++ b/man/synCreateExternalS3FileHandle.Rd
@@ -45,6 +45,7 @@ synCreateExternalS3FileHandle(bucket_name, s3_file_key, file_path, parent=NULL, 
 
 \examples{
 \dontrun{
+library("aws.s3")
 
 # create a storage location
 folder_and_storage_location <- synCreateS3StorageLocation(parent='syn123', folder_name='test_folder', bucket_name='aws-bucket-name', base_key='test', sts_enabled=TRUE)

--- a/man/synCreateExternalS3FileHandle.Rd
+++ b/man/synCreateExternalS3FileHandle.Rd
@@ -44,7 +44,7 @@ synCreateExternalS3FileHandle(bucket_name, s3_file_key, file_path, parent=NULL, 
 }
 
 \examples{
-\dontun{
+\dontrun{
 
 # create a storage location
 folder_and_storage_location <- synCreateS3StorageLocation(parent='syn123', folder_name='test_folder', bucket_name='aws-bucket-name', base_key='test', sts_enabled=TRUE)

--- a/man/synCreateExternalS3FileHandle.Rd
+++ b/man/synCreateExternalS3FileHandle.Rd
@@ -1,0 +1,72 @@
+\name{synCreateExternalS3FileHandle}
+\alias{synCreateExternalS3FileHandle}
+\docType{methods}
+\title{
+synCreateExternalS3FileHandle
+}
+\description{
+Create an external S3 file handle for e.g. a file that has been uploaded directly to
+an external S3 storage location.
+}
+\usage{
+synCreateExternalS3FileHandle(bucket_name, s3_file_key, file_path, parent=NULL, storage_location_id=NULL, mimetype=NULL)
+}
+\arguments{
+\item{bucket_name}{             Name of the S3 bucket\cr
+}
+\item{s3_file_key}{             S3 key of the uploaded object\cr
+}
+\item{file_path}{               Local path of the uploaded file\cr
+}
+\item{parent}{                  Parent entity to create the file handle in, the file handle will be created\cr
+                                    in the default storage location of the parent. Mutually exclusive with\cr
+                                    storage_location_id\cr
+}
+\item{storage_location_id}{     Explicit storage location id to create the file handle in, mutually exclusive\cr
+                                    with parent\cr
+}
+\item{mimetype}{                Mimetype of the file, if known}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+
+\examples{
+\dontun{
+
+# create a storage location
+folder_and_storage_location <- synCreateS3StorageLocation(parent='syn123', folder_name='test_folder', bucket_name='aws-bucket-name', base_key='test', sts_enabled=TRUE)
+
+storage_location <- folder_and_storage_location[[2]]
+
+# get a write permission token
+folder <- folder_and_storage_location[[1]]
+folder_id <- folder$properties$id
+sts_write_token <- synGetStsStorageToken(entity=folder_id, permission='read_write', output_format='json')
+
+# configure the environment with AWS token
+Sys.setenv('AWS_ACCESS_KEY_ID'=sts_write_token$accessKeyId, 'AWS_SECRET_ACCESS_KEY'=sts_write_token$secretAccessKey, 'AWS_SESSION_TOKEN'=sts_write_token$sessionToken)
+
+# upload a file directly to s3
+put_object(file='/tmp/foo.txt', object='test/foo.txt', bucket='aws-bucket-name')
+
+# create a file handle for the object
+synCreateExternalS3FileHandle(bucket_name='aws-bucket-name', s3_file_key='test/foo.txt', file_path='/tmp/foo.txt', storage_location_id=storage_location$storageLocationId) 
+
+}
+}
+
+
+

--- a/man/synCreateS3StorageLocation.Rd
+++ b/man/synCreateS3StorageLocation.Rd
@@ -34,7 +34,7 @@ synCreateS3StorageLocation(parent=NULL, folder_name=NULL, folder=NULL, bucket_na
 % A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
 }
 \value{
- a 3-tuple of the synapse Folder, a the storage location setting, and the project setting dictionaries
+ a 3 element list of the synapse Folder, a the storage location setting, and the project setting dictionaries
 }
 \references{
 % A section with references to the literature. Use \url{} or \href{}{} for web pointers.

--- a/man/synCreateS3StorageLocation.Rd
+++ b/man/synCreateS3StorageLocation.Rd
@@ -34,7 +34,7 @@ synCreateS3StorageLocation(parent=NULL, folder_name=NULL, folder=NULL, bucket_na
 % A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
 }
 \value{
-
+ a 3-tuple of the synapse Folder, a the storage location setting, and the project setting dictionaries
 }
 \references{
 % A section with references to the literature. Use \url{} or \href{}{} for web pointers.

--- a/man/synCreateS3StorageLocation.Rd
+++ b/man/synCreateS3StorageLocation.Rd
@@ -1,0 +1,58 @@
+\name{synCreateS3StorageLocation}
+\alias{synCreateS3StorageLocation}
+\docType{methods}
+\title{
+synCreateS3StorageLocation
+}
+\description{
+Create a storage location in the given parent, either in the given folder or by creating a new
+folder in that parent with the given name. This will both create a StorageLocationSetting,
+and a ProjectSetting together, optionally creating a new folder in which to locate it,
+and optionally enabling this storage location for access via STS. If enabling an existing folder for STS,
+it must be empty.
+}
+\usage{
+synCreateS3StorageLocation(parent=NULL, folder_name=NULL, folder=NULL, bucket_name=NULL, base_key=NULL, sts_enabled=FALSE)
+}
+\arguments{
+\item{parent}{              The parent in which to locate the storage location (mutually exclusive with folder)\cr
+}
+\item{folder_name}{         The name of a new folder to create (mutually exclusive with folder)\cr
+}
+\item{folder}{              The existing folder in which to create the storage location\cr
+                                (mutually exclusive with folder_name)\cr
+}
+\item{bucket_name}{         The name of an S3 bucket, if this is an external storage location,\cr
+                                if None will use Synapse S3 storage\cr
+}
+\item{base_key}{            The base key of within the bucket, None to use the bucket root,\cr
+                                only applicable if bucket_name is passed\cr
+}
+\item{sts_enabled}{         Whether this storage location should be STS enabled}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+\examples{
+\dontrun{
+folder_and_storage_location <- synCreateS3StorageLocation(parent='syn123', folder_name='test_folder', bucket_name='aws-bucket-name', base_key='key/in/bucket', sts_enabled=TRUE)
+
+folder <- folder_and_storage_location[[1]]
+storage_location <- folder_and_storage_location[[2]]
+
+}
+}
+
+

--- a/man/synCreateSnapshotVersion.Rd
+++ b/man/synCreateSnapshotVersion.Rd
@@ -1,0 +1,49 @@
+\name{synCreateSnapshotVersion}
+\alias{synCreateSnapshotVersion}
+\docType{methods}
+\title{
+synCreateSnapshotVersion
+}
+\description{
+Create a new Table Version or a new View version.
+}
+\usage{
+synCreateSnapshotVersion(table, comment=NULL, label=NULL, activity=NULL, wait=TRUE)
+}
+\arguments{
+\item{table}{  The schema of the Table/View, or its ID.\cr
+}
+\item{comment}{  Optional snapshot comment.\cr
+}
+\item{label}{  Optional snapshot label.\cr
+}
+\item{activity}{  Optional activity ID applied to snapshot version.\cr
+}
+\item{wait}{ True if this method should return the snapshot version after waiting for any necessary\cr
+                asynchronous table updates to complete. If False this method will return return\cr
+                as soon as any updates are initiated.}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ the snapshot version number if wait=True, None if wait=False
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+
+\examples{
+\dontrun{
+synCreateSnapshotVersion(table='syn123', comment='snapshot comment', wait=TRUE)
+}
+}
+
+
+

--- a/man/synGetMembershipStatus.Rd
+++ b/man/synGetMembershipStatus.Rd
@@ -1,0 +1,44 @@
+\name{synGetMembershipStatus}
+\alias{synGetMembershipStatus}
+\docType{methods}
+\title{
+synGetMembershipStatus
+}
+\description{
+Retrieve a user's Team Membership Status bundle.
+https://docs.synapse.org/rest/GET/team/id/member/principalId/membershipStatus.html
+}
+\usage{
+synGetMembershipStatus(userid, team, user=NULL)
+}
+\arguments{
+\item{userid}{}
+\item{team}{ A Team object or a\cr
+             team's ID.}
+\item{user}{optional named parameter:  Synapse user ID\cr
+}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ dict of TeamMembershipStatus
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+\examples{
+\dontrun{
+synGetMembershipStatus(user_id, team_id)$isMember
+
+}
+}
+
+
+

--- a/man/synGetStsStorageToken.Rd
+++ b/man/synGetStsStorageToken.Rd
@@ -1,0 +1,66 @@
+\name{synGetStsStorageToken}
+\alias{synGetStsStorageToken}
+\docType{methods}
+\title{
+synGetStsStorageToken
+}
+\description{
+Get STS credentials for the given entity_id and permission, outputting it in the given format
+}
+\usage{
+synGetStsStorageToken(entity, permission, output_format=json, min_remaining_life=NULL)
+}
+\arguments{
+\item{entity}{          the entity or entity id whose credentials are being returned\cr
+}
+\item{permission}{      one of 'read_only' or 'read_write'\cr
+}
+\item{output_format}{   one of 'json', 'boto', 'shell', 'bash', 'cmd', 'powershell'\cr
+                        json: the dictionary returned from the Synapse STS API including expiration\cr
+                        boto: a dictionary compatible with a boto session (aws_access_key_id, etc)\cr
+                        shell: output commands for exporting credentials appropriate for the detected shell\cr
+                        bash: output commands for exporting credentials into a bash shell\cr
+                        cmd: output commands for exporting credentials into a windows cmd shell\cr
+                        powershell: output commands for exporting credentials into a windows powershell\cr
+}
+\item{min_remaining_life}{ the minimum allowable remaining life on a cached token to return. if a cached token\cr
+    has left than this amount of time left a fresh token will be fetched}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+\examples{
+\dontrun{
+library("aws.s3")
+
+# create a storage location
+folder_and_storage_location <- synCreateS3StorageLocation(parent='syn123', folder_name='test_folder', bucket_name='aws-bucket-name', base_key='test', sts_enabled=TRUE)
+
+folder <- folder_and_storage_location[[1]]
+storage_location <- folder_and_storage_location[[2]]
+
+# get a write permission token
+sts_write_token <- synGetStsStorageToken(entity=folder$properties$id, permission='read_write')
+
+# configure the environment with AWS token
+Sys.setenv('AWS_ACCESS_KEY_ID'=sts_write_token$accessKeyId, 'AWS_SECRET_ACCESS_KEY'=sts_write_token$secretAccessKey, 'AWS_SESSION_TOKEN'=sts_write_token$sessionToken)
+
+# upload the file directly to s3
+put_object(file='/tmp/foo.txt', object='test/foo.txt', bucket='aws-bucket-name')
+
+}
+}
+
+

--- a/man/synIsCertified.Rd
+++ b/man/synIsCertified.Rd
@@ -30,8 +30,8 @@ synIsCertified(user)
 }
 % for testing that should not be shown to users, but will be run by example(). 
 \examples{
-\dontrun {
-synIsCertifed(user_id)
+\dontrun{
+synIsCertified(user_id)
 }
 }
 

--- a/man/synIsCertified.Rd
+++ b/man/synIsCertified.Rd
@@ -1,0 +1,39 @@
+\name{synIsCertified}
+\alias{synIsCertified}
+\docType{methods}
+\title{
+synIsCertified
+}
+\description{
+Determines whether a Synapse user is a certified user.
+}
+\usage{
+synIsCertified(user)
+}
+\arguments{
+\item{user}{}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ True if the Synapse user is certified
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+% for testing that should not be shown to users, but will be run by example(). 
+\examples{
+\dontrun {
+synIsCertifed(user_id)
+}
+}
+
+
+

--- a/man/synLogin.Rd
+++ b/man/synLogin.Rd
@@ -27,6 +27,9 @@ On Windows and Mac OS, a default credentials storage exists so it will be prefer
 \item{silent}{     Defaults to FALSE.  Suppresses the "Welcome ...!" message.\cr
 }
 \item{forced}{     Defaults to FALSE.  Bypass the credential cache if set.}
+
+\item{authToken}{  A bearer authorization token, e.g. a personal access token, can be used in lieu of a\cr
+                        password or apiKey}
 }
 \details{
 Valid combinations of login() arguments:\cr
@@ -52,7 +55,13 @@ If no login arguments are provided or only username is provided, login() will at
 }
 \examples{ 
 \dontrun{
+
+# with username/pass
 synLogin('myUsername', 'secretPassword')
+
+# with a token, e.g. an access obtained from your Synapse profile
+synLogin(authToken=token)
+
 }
 }
 

--- a/man/synSendMembershipInvitation.Rd
+++ b/man/synSendMembershipInvitation.Rd
@@ -1,0 +1,47 @@
+\name{synSendMembershipInvitation}
+\alias{synSendMembershipInvitation}
+\docType{methods}
+\title{
+synSendMembershipInvitation
+}
+\description{
+Create a membership invitation and send an email notification
+to the invitee.
+}
+\usage{
+synSendMembershipInvitation(teamId, inviteeId=NULL, inviteeEmail=NULL, message=NULL)
+}
+\arguments{
+\item{teamId}{ Synapse teamId\cr
+}
+\item{inviteeId}{ Synapse username or profile id of user\cr
+}
+\item{inviteeEmail}{ Email of user\cr
+}
+\item{message}{ Additional message for the user getting invited to the\cr
+                team. Default to None.}
+}
+\details{
+% A detailed if possible precise description of the functionality provided, extending the basic information in the \description slot.
+}
+\value{
+ MembershipInvitation
+}
+\references{
+% A section with references to the literature. Use \url{} or \href{}{} for web pointers.
+}
+\note{
+% Use this for a special note you want to have pointed out. 
+}
+\seealso{
+% Pointers to related R objects, using \code{\link{...}} to refer to them.
+}
+\examples{
+\dontrun{
+synSendMembershipInviation(teamId, inviteeEmail='john.doe@example.com', message='You should join this Synapse team!')
+
+}
+}
+
+
+


### PR DESCRIPTION
Any Synapse python functions with underscores in them would generate generic methods in synapser that would not be exported because of the configured NAMESPACE rule. For example the Python `Synapse#create_snapshot_version` function would be converted to `synCreate_snapshot_version` which would not be exported because it still had underscores in its name.

In the companion PythonEmbedInR change https://github.com/Sage-Bionetworks/PythonEmbedInR/pull/102 all names are fully converted to camel case. This change then ensures that the newly exposed functions have the expected man documentation. It also avoids for now a conflict between two versions of annotation functions in the Python client (e.g. `setAnnotations` and `set_annotations` which would convert to the same camel case of `synSetAnnotations`. For now the old behavior is preserved to ensure backwards compatibility, and the new signatures are not included in synapser (they weren't before either because of the underscore issue).