### PR TITLE
IT-2111: Implement OIDC authentication to AWS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,15 @@ jobs:
         with:
           path: deploy_artifacts
 
+        # Before deoloying to RAN (which is an S3 bucket), authenticate to AWS using GitHub OIDC
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::325565585839:role/sagebase-github-oidc-sage-bionetworks-synapser
+          role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: 1200
+          
       - name: deploy-to-target
         id: deploy-to-target
         if: ${{steps.check-deployment-target.outputs.deploy_target != ''}}
@@ -235,14 +244,8 @@ jobs:
 
           export ARTIFACTS_DIR=deploy_artifacts
           if [[ "$DEPLOY_TARGET" == "staging" ]]; then
-            export AWS_ACCESS_KEY_ID=${{secrets.S3_RAN_STAGING_AWS_ACCESS_KEY_ID}}
-            export AWS_SECRET_ACCESS_KEY=${{secrets.S3_RAN_STAGING_AWS_SECRET_ACCESS_KEY}}
-            export AWS_DEFAULT_REGION=us-east-1
             export S3_RAN=staging-ran.synapse.org
           elif [[ "$DEPLOY_TARGET" == "prod" ]]; then
-            export AWS_ACCESS_KEY_ID=${{secrets.S3_RAN_PROD_AWS_ACCESS_KEY_ID}}
-            export AWS_SECRET_ACCESS_KEY=${{secrets.S3_RAN_PROD_AWS_SECRET_ACCESS_KEY}}
-            export AWS_DEFAULT_REGION=us-east-1
             export S3_RAN=ran.synapse.org
           fi
 


### PR DESCRIPTION
When publishing the package artifacts to our "RAN" (an S3 bucket), GitHub needs to authenticate to AWS.  This change allows the `synapser` repo' to authenticate using OIDC, allowing us to remove the previously used, dedicated IAM user from the AWS Synapse Prod account.