### PR TITLE
[SYNR-1531]Pin rjson version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
   reticulate(>= 1.25),
   reticulate(<= 1.28),
   methods,
-  rjson,
+  rjson(<=0.2.21),
   stats,
   utils
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Depends:
   R(< 4.5)
 Remotes:
   reticulate@1.28
+  rjson@0.2.21
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Depends:
   R(>= 4.1.3),
   R(< 4.5)
 Remotes:
-  reticulate@1.28
+  reticulate@1.28,
   rjson@0.2.21
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
   reticulate(>= 1.25),
   reticulate(<= 1.28),
   methods,
-  rjson(<=0.2.21),
+  rjson(<= 0.2.21),
   stats,
   utils
 Depends:


### PR DESCRIPTION
Problem:

On 8/2/2024, the latest version 0.2.22 was updated to only [support R4.4.0](https://cran.r-project.org/web/packages/rjson/index.html) or newer versions. This broke our builds in both synapser and synapserutils. Since synapser and synapserutils supports R 4.1 - 4.4, we would need to pin rjson version to an older version, 0.2.21, so it can support R versions older than 4.4.

Solution:

Pin rjson version in the DESCRIPTION file. 