### PR TITLE
Enable multithreading in synapse python client

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,7 @@
   
   reticulate::py_run_string(sprintf("synapserVersion = 'synapser/%s' ", utils::packageVersion("synapser")))
   reticulate::py_run_string("synapseclient.USER_AGENT['User-Agent'] = synapserVersion + ' '+ synapseclient.USER_AGENT['User-Agent']")
-  reticulate::py_run_string("synapseclient.core.config.single_threaded = True")
+  reticulate::py_run_string("synapseclient.core.config.single_threaded = False")
   reticulate::py_run_string("syn=synapseclient.Synapse(skip_checks=True, debug=False)")
   # make syn available in the global environment
   syn <<- reticulate::py_eval("syn")


### PR DESCRIPTION
As discussed [here](https://sagebionetworks.slack.com/archives/CMSGC6ATD/p1731508826454179), synapser is configured to disable multithreading in the synapse python client. Previously, when the R client was implemented with PythonEmbedInR, multithreading caused issues. Currently, it uses reticulate, which appears to support python multithreading, from digging through the issues on the reticulate repository. However, I did notice several examples of folks struggling with this on Windows, so that should be a priority for testing. 

On a mac, I had no issues with downloading or uploading with multi threading enabled. It increased my download speed from ~14-15 MB/s to ~90 MB/s. I didn't test upload speed with multi threading disabled, but with it enabled the upload speed was ~110 MB/s.

