### PR TITLE
[SYNPY-1607] Interface re-write and version un-pinning initiative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ synapse.Rproj
 inst/doc
 *.pyc
 .venv
+
+launch.json

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Authors@R: c(
   person("Dan", "Lu", role = c("aut", "cre"), email = "dan.lu@sagebase.org"),
   person("Tom", "Yu", role = c("aut"), email = "thomas.yu@sagebase.org"),
   person("Bruce", "Hoff", role = c("aut"), email = "bruce.hoff@sagebase.org"),
+  person("Bryan", "Fauble", role = c("aut"), email = "bryan.fauble@sagebase.org"),
   person("Sage Bionetworks", role = c("cph"))
   )
 BugReports: https://github.com/Sage-Bionetworks/synapser/issues
@@ -15,17 +16,15 @@ Encoding: UTF-8
 License: Apache License 2.0
 Imports:
   reticulate(>= 1.25),
-  reticulate(<= 1.28),
   methods,
-  rjson(<= 0.2.21),
+  rjson,
   stats,
   utils
 Depends:
-  R(>= 4.1.3),
-  R(< 4.5)
+  R(>= 4.1.3)
 Remotes:
-  reticulate@1.28,
-  rjson@0.2.21
+  reticulate,
+  rjson
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org
 VignetteBuilder: knitr

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -1015,6 +1015,7 @@ getDictDocString <- function(templateDir) {
   connection <- file(file, open = "r")
   result <- paste(readLines(connection), collapse = "\n")
   close(connection)
+  result
 }
 
 # any conversion of Sphinx text to Latex text goes here

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -205,8 +205,6 @@ defineFunctionalClassMethod <- function(module, setGenericCallback, className, m
   # Apply custom mapping if provided
   functionalRFunctionName <- applyFunctionNameMapping(
     defaultFunctionalName, 
-    className, 
-    methodName, 
     functionNameMapping
   )
   
@@ -1364,9 +1362,7 @@ generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", f
           
           # Apply custom mapping if provided
           functionalRFunctionName <- applyFunctionNameMapping(
-            defaultFunctionalName, 
-            c$name, 
-            method$name, 
+            defaultFunctionalName,
             functionNameMapping
           )
           
@@ -1407,10 +1403,8 @@ generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", f
 # Helper function to apply function name mapping if configured
 #
 # @param defaultName the default generated function name
-# @param className the name of the Python class
-# @param methodName the name of the method
 # @param mappingConfig the mapping configuration list
-applyFunctionNameMapping <- function(defaultName, className, methodName, mappingConfig = NULL) {
+applyFunctionNameMapping <- function(defaultName, mappingConfig = NULL) {
   if (is.null(mappingConfig)) {
     return(defaultName)
   }

--- a/R/shared.R
+++ b/R/shared.R
@@ -48,12 +48,18 @@
   "set_annotations",
   "fill_from_dict",
   "to_synapse_request",
-  "allow_client_caching"
+  "allow_client_caching",
+  "invite_to_team"
 )
 
 .modelClassMethodsToOmit <- c(
   "query",
-  "query_part_mask"
+  "query_part_mask",
+  "format_for_manifest",
+  "from_id",
+  "from_parent",
+  "from_name",
+  "from_username"
 )
 
 .synapseClientClassFilter <- function(x) {
@@ -98,3 +104,20 @@
   }
   x
 }
+
+
+# Helper function to get predefined function name mapping for synapseclient.models
+#
+# @return A list containing explicit mapping configuration for synapseclient.models functions
+.synapseClientModelsMapping <- function() {
+  list(
+    explicit = list(
+      "synDisassociateFromEntityActivity" = "synDisassociateActivityFromEntity",
+      "synFromPathFile" = "synGetFileFromPath",
+      "synInviteTeam" = "synInviteToTeam",
+      "synMembersTeam" = "synGetTeamMembers",
+      "synOpenInvitationsTeam" = "synGetTeamOpenInvitations"
+    )
+  )
+}
+

--- a/R/table.R
+++ b/R/table.R
@@ -1,3 +1,6 @@
+# TODO: Most if not all of this functionality may not need to exist anymore. More verification is needed.
+
+
 # Utilities for working with table in synapser
 #
 # Author: kimyen

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -66,7 +66,9 @@
                     functionFilter = .removeAsyncFunctionFilter,
                     classFilter = .synapseModelClassFilter,
                     functionPrefix = "syn",
-                    generateFunctionalInterface = TRUE)
+                    generateFunctionalInterface = TRUE,
+                    functionNameMapping = .synapseClientModelsMapping()
+                    )
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,10 +12,10 @@
       # Ideally we would source tools/installPythonClient.R to not
       # have to duplicate the synapseclient install code
       # system2(paste("Rscript ", getwd(), "/tools/installPythonClient.R ", getwd(), sep=""))
-      PYTHON_CLIENT_VERSION <- '4.4.0'
+      PYTHON_CLIENT_VERSION <- '4.8.0'
       # reticulate::virtualenv_create('r-reticulate')
       # reticulate::use_virtualenv('r-reticulate')
-      reticulate::py_install(c("pandas>=1.5,<=2.0.3", "jinja2", "markupsafe","numpy<=1.24.4"))
+      reticulate::py_install(c("pandas>=1.5,<3.0", "jinja2", "markupsafe","numpy>=1.24.0"))
       reticulate::py_install(c(paste("synapseclient==", PYTHON_CLIENT_VERSION, sep="")), pip=T)
       reticulate::py_run_string("import synapseclient")
     }
@@ -32,7 +32,7 @@
   .defineRPackageFunctions()
   # .defineOverloadFunctions() must come AFTER .defineRPackageFunctions()
   # because it redefines selected generic functions
-  .defineOverloadFunctions()
+  # .defineOverloadFunctions()
   
   # mute Python warnings
   reticulate::py_run_string("import warnings")
@@ -58,39 +58,17 @@
                     functionFilter = .synapseClassFunctionFilter,
                     functionPrefix = "syn",
                     pySingletonName = "syn")
-  # exposing all supporting classes except for Synapse itself and some selected classes.
-  generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient",
+
+  generateRWrappers(pyPkg = "synapseclient.models",
+                    container = "synapseclient.models",
                     setGenericCallback = .setGenericCallback,
                     assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .removeAllFunctionsFunctionFilter,
-                    classFilter = .synapseClientClassFilter)
-  # cherry picking and exposing function Table
-  generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient.table",
-                    setGenericCallback = .setGenericCallback,
-                    assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .cherryPickTableFunctionFilter,
-                    classFilter = .removeAllClassesClassFilter,
-                    functionPrefix = "syn")
+                    functionFilter = .removeAsyncFunctionFilter,
+                    classFilter = .synapseModelClassFilter,
+                    functionPrefix = "syn",
+                    generateFunctionalInterface = TRUE)
 }
 
-# TODO: This section is removed since it causes the infinite recursion 
-# issue when reading downloaded entity to a dataframe. Revisit this
-# when deprecating PythonEmbedInR code
-# .objectDefinitionHelper <- function(object) {
-#   if (methods::is(object, "CsvFileTable")) {
-#     # reading from csv
-#     # Removed due to Error in unlockBinding("asDataFrame", object) : no binding for "asDataFrame"
-#     # unlockBinding("asDataFrame", object)
-#     object$asDataFrame <- function() {
-#       .readCsvBasedOnSchema(object)
-#     }
-#     # Removed due to Error in lockBinding("asDataFrame", object) : no binding for "asDataFrame"
-#     # lockBinding("asDataFrame", object)
-#   }
-#   object
-# }
 
 .onAttach <- function(libname, pkgname) {
   tou <- "\nTERMS OF USE NOTICE:
@@ -104,72 +82,73 @@
   packageStartupMessage(tou)
 }
 
-.defineOverloadFunctions <- function() {
-  methods::setGeneric(
-    name ="Table",
-    def = function(schema, values, ...){
-      do.call("synTable", args = list(schema, values, ...))
-    }
-  )
-  methods::setMethod(
-    f = "Table",
-    signature = c("character", "data.frame"),
-    definition = function(schema, values) {
-      file <- tempfile()
-      .saveToCsv(values, file)
-      Table(schema, file)
-    }
-  )
-  methods::setMethod(
-    f = "Table",
-    signature = c("ANY", "data.frame"),
-    definition = function(schema, values) {
-      file <- tempfile()
-      .saveToCsvWithSchema(schema, values, file)
-      Table(schema, file)
-    }
-  )
+# TODO: These are likely not needed, however more verification is needed.
+# .defineOverloadFunctions <- function() {
+#   methods::setGeneric(
+#     name ="Table",
+#     def = function(schema, values, ...){
+#       do.call("synTable", args = list(schema, values, ...))
+#     }
+#   )
+#   methods::setMethod(
+#     f = "Table",
+#     signature = c("character", "data.frame"),
+#     definition = function(schema, values) {
+#       file <- tempfile()
+#       .saveToCsv(values, file)
+#       Table(schema, file)
+#     }
+#   )
+#   methods::setMethod(
+#     f = "Table",
+#     signature = c("ANY", "data.frame"),
+#     definition = function(schema, values) {
+#       file <- tempfile()
+#       .saveToCsvWithSchema(schema, values, file)
+#       Table(schema, file)
+#     }
+#   )
   
-  methods::setMethod(
-    f = "synBuildTable",
-    signature = c("ANY", "ANY", "data.frame"),
-    definition = function(name, parent, values) {
-      file <- tempfile()
-      .saveToCsv(values, file)
-      synBuildTable(name, parent, file)
-    }
-  )
+#   methods::setMethod(
+#     f = "synBuildTable",
+#     signature = c("ANY", "ANY", "data.frame"),
+#     definition = function(name, parent, values) {
+#       file <- tempfile()
+#       .saveToCsv(values, file)
+#       synBuildTable(name, parent, file)
+#     }
+#   )
 
-  methods::setClass("CsvFileTable")
-  methods::setMethod(
-    f = "as.data.frame",
-    signature = c(x = "CsvFileTable"),
-    definition = function(x) {
-      .readCsvBasedOnSchema(x)
-    }
-  )
+#   methods::setClass("CsvFileTable")
+#   methods::setMethod(
+#     f = "as.data.frame",
+#     signature = c(x = "CsvFileTable"),
+#     definition = function(x) {
+#       .readCsvBasedOnSchema(x)
+#     }
+#   )
   
-  methods::setClass("GeneratorWrapper")
-  methods::setMethod(
-    f = "as.list",
-    signature = c(x = "GeneratorWrapper"),
-    definition = function(x) {
-      x$asList()
-    }
-  )
+#   methods::setClass("GeneratorWrapper")
+#   methods::setMethod(
+#     f = "as.list",
+#     signature = c(x = "GeneratorWrapper"),
+#     definition = function(x) {
+#       x$asList()
+#     }
+#   )
   
-  methods::setGeneric(
-    name = "nextElem",
-    def = function(x) {
-      standardGeneric("nextElem")
-    }
-  )
+#   methods::setGeneric(
+#     name = "nextElem",
+#     def = function(x) {
+#       standardGeneric("nextElem")
+#     }
+#   )
   
-  methods::setMethod(
-    f = "nextElem",
-    signature = c(x = "GeneratorWrapper"),
-    definition = function(x) {
-      x$nextElem()
-    }
-  )
-}
+#   methods::setMethod(
+#     f = "nextElem",
+#     signature = c(x = "GeneratorWrapper"),
+#     definition = function(x) {
+#       x$nextElem()
+#     }
+#   )
+# }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
       PYTHON_CLIENT_VERSION <- '4.8.0'
       # reticulate::virtualenv_create('r-reticulate')
       # reticulate::use_virtualenv('r-reticulate')
-      reticulate::py_install(c("pandas>=1.5,<3.0", "jinja2", "markupsafe","numpy>=1.24.0"))
+      reticulate::py_install(c("pandas>=1.5", "jinja2", "markupsafe","numpy>=1.24.0"))
       reticulate::py_install(c(paste("synapseclient==", PYTHON_CLIENT_VERSION, sep="")), pip=T)
       reticulate::py_run_string("import synapseclient")
     }

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -3,33 +3,40 @@ from abbreviateStackTrace import abbreviateStackTrace
 from patchStdoutStdErr import patch_stdout_stderr
 from synapseclient.annotations import Annotations
 
+
 class GeneratorWrapper():
     def __init__(self, wrapped):
-       self._inner = wrapped
-       self._use_list = False
-       self._use_iter = False
+        self._inner = wrapped
+        self._use_list = False
+        self._use_iter = False
 
     def nextElem(self):
-      if self._use_list:
-        raise Exception("Have already enumerated all elements.")
-      self._use_iter = True
-      return self._inner.__next__()
+        if self._use_list:
+            raise Exception("Have already enumerated all elements.")
+        self._use_iter = True
+        return self._inner.__next__()
 
     def asList(self):
-      if self._use_iter:
-        raise Exception("Can't generate a list once enumeration has begun.")
-      if self._use_list:
-        raise Exception("Have already enumerated all elements.")
-      self._use_list = True
-      return list(self._inner)
+        if self._use_iter:
+            raise Exception(
+                "Can't generate a list once enumeration has begun.")
+        if self._use_list:
+            raise Exception("Have already enumerated all elements.")
+        self._use_list = True
+        return list(self._inner)
 
 # from https://stackoverflow.com/questions/972/adding-a-method-to-an-existing-object-instance#2982
+
+
 def generatorModifier(g):
     # add a public method to get the next value from a generator or iterator
     if isinstance(g, types.GeneratorType):
         return GeneratorWrapper(g)
     else:
         return g
+
+# TODO: This is likely not needed anymore, as the annotations are now dictionaries
+
 
 def annotationsModifier(a):
     # convert to a simple dictionary
@@ -39,6 +46,8 @@ def annotationsModifier(a):
         return a
 
 # expects a dict with the keys: method (a list of [object, method name]), args, and kwargs
+
+
 def invoke(**kwargs):
     patch_stdout_stderr()
     method = kwargs['method']
@@ -46,5 +55,3 @@ def invoke(**kwargs):
     kw = dict(kwargs['kwargs'])
     method_to_call = getattr(method[0], method[1])
     return annotationsModifier(generatorModifier(abbreviateStackTrace(lambda: method_to_call(*args, **kw))))
-
-

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -1,11 +1,36 @@
 import inspect
-# import gateway
+import sys
+from typing import Protocol
+
+
+def is_method_from_protocol(method_func, class_definition) -> bool:
+    """
+    Check if a method comes from a Protocol class or mixin by examining the MRO
+    and looking for classes that define this method and are part of the
+    synapseclient protocol/mixin system.
+    """
+    if Protocol is None:
+        return False
+
+    method_name = method_func.__name__
+
+    for base_class in class_definition.__mro__:
+        if base_class is class_definition or base_class is object:
+            continue
+
+        if (issubclass(base_class, Protocol) and
+                method_name in base_class.__dict__ and
+                callable(getattr(base_class, method_name, None))):
+            return True
+
+    return False
+
 
 def isFunctionOrRoutine(member):
     return inspect.isfunction(member) or inspect.isroutine(member)
 
+
 def argspecContent(fn):
-    # follow_wrapped since we generally are not concerned about decorators
     fn_signature = inspect.signature(fn, follow_wrapped=True)
 
     args = []
@@ -29,17 +54,156 @@ def argspecContent(fn):
         'defaults': tuple(defaults),
     }
 
-def getCleanedDoc(member):
-    doc = inspect.getdoc(member)
-    if doc is None:
+
+def getCleanedDoc(member, class_context=None):
+    """
+    Extract and clean docstrings from a member, collecting all docstrings
+    found at any level of wrapped functions.
+
+    Args:
+        member: The function/method to extract docstring from
+        class_context: The class that the member belongs to (if applicable)
+    """
+
+    if (hasattr(member, '__module__') and
+            'synapseclient.models' not in member.__module__):
+        doc = inspect.getdoc(member)
+        if doc:
+            return inspect.cleandoc(doc)
+
+    all_docstrings = []
+
+    def _find_protocol_method_docstring(func):
+        """Find the docstring from the Protocol class."""
+        func_name = getattr(func, '__name__', '')
+
+        target_class = None
+
+        if class_context is not None:
+            target_class = class_context
+
+        elif hasattr(func, '__self__') and func.__self__ is not None:
+            target_class = func.__self__.__class__
+
+        elif hasattr(func, '__qualname__') and '.' in func.__qualname__:
+            parts = func.__qualname__.split('.')
+            if len(parts) >= 2:
+                class_name = parts[0]
+
+                if hasattr(func, '__module__'):
+                    module = sys.modules.get(func.__module__)
+                    if module and hasattr(module, class_name):
+                        potential_class = getattr(module, class_name)
+                        if inspect.isclass(potential_class):
+                            target_class = potential_class
+
+        if target_class is None and hasattr(func, '__module__'):
+            for module_name, module in sys.modules.items():
+                if (module and
+                        'synapseclient.models' in module_name and
+                        hasattr(module, '__dict__')):
+                    for attr_name, attr_value in module.__dict__.items():
+                        if (inspect.isclass(attr_value) and
+                                hasattr(attr_value, func_name) and
+                                callable(getattr(attr_value, func_name))):
+                            target_class = attr_value
+                            break
+                if target_class:
+                    break
+
+        if target_class is None:
+            return None
+
+        def _search_protocol_in_class_hierarchy(cls, method_name,
+                                                visited=None):
+            """Recursively search for Protocol method docstring."""
+            if visited is None:
+                visited = set()
+
+            if cls in visited:
+                return None
+            visited.add(cls)
+
+            for base_class in cls.__mro__:
+                if base_class is cls or base_class is object:
+                    continue
+
+                is_protocol_class = issubclass(base_class, Protocol)
+
+                if is_protocol_class:
+                    if (method_name in base_class.__dict__ and
+                            callable(getattr(base_class, method_name, None))):
+                        protocol_method = getattr(base_class, method_name)
+                        protocol_doc = inspect.getdoc(protocol_method)
+                        if protocol_doc:
+                            return protocol_doc
+
+                elif (hasattr(base_class, '__mro__') and
+                      len(base_class.__mro__) > 2):
+                    result = _search_protocol_in_class_hierarchy(
+                        base_class, method_name, visited)
+                    if result:
+                        return result
+
+            return None
+
+        protocol_doc = _search_protocol_in_class_hierarchy(
+            target_class, func_name)
+        if protocol_doc:
+            return protocol_doc
+
+        for module_name, module in sys.modules.items():
+            if module and hasattr(module, '__dict__'):
+                for attr_name, attr_value in module.__dict__.items():
+                    if (inspect.isclass(attr_value) and
+                            Protocol and
+                            attr_value is not Protocol):
+                        if issubclass(attr_value, Protocol):
+                            if (hasattr(attr_value, func_name) and
+                                    callable(getattr(
+                                        attr_value, func_name))):
+                                protocol_method = getattr(
+                                    attr_value, func_name)
+                                protocol_doc = inspect.getdoc(
+                                    protocol_method)
+                                if protocol_doc:
+                                    return protocol_doc
+
         return None
-    else:
-        return inspect.cleandoc(doc)
+
+    async_marker = 'The new method that will replace the non-async method'
+    if (hasattr(member, '__name__') and
+            hasattr(member, '__module__') and
+            ('async_to_sync' in str(type(member)) or
+             (inspect.getdoc(member) and
+              async_marker in inspect.getdoc(member)))):
+
+        protocol_doc = _find_protocol_method_docstring(member)
+        if protocol_doc and protocol_doc not in all_docstrings:
+            all_docstrings.insert(0, protocol_doc)
+
+    if not all_docstrings:
+        if (hasattr(member, '__module__') and
+                'synapseclient.models' in member.__module__):
+            doc = inspect.getdoc(member)
+            if doc:
+                return inspect.cleandoc(doc)
+
+        return None
+
+    for doc in all_docstrings:
+        if doc and async_marker not in doc:
+            return inspect.cleandoc(doc)
+
+    return inspect.cleandoc(all_docstrings[0])
+
 
 def methodAttributes(name, method):
     args = argspecContent(method)
     cleaneddoc = getCleanedDoc(method)
-    return({'name':name, 'args':args, 'doc':cleaneddoc, 'module':method.__module__})
+    return ({'name': name, 'args': args, 'doc': cleaneddoc,
+             'module': method.__module__})
+
 
 def getFunctionInfo(module):
     result = []
@@ -51,41 +215,168 @@ def getFunctionInfo(module):
         result.append(methodAttributes(name, method))
     return result
 
+
 def getEnumInfo(module):
+    import ast
+
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        if name != "Enum" and str(type(classdefinition))=="<class 'enum.EnumMeta'>":
+        if (name != "Enum" and
+                (str(type(classdefinition)) == "<class 'enum.EnumMeta'>" or
+                 str(type(classdefinition)) == "<class 'enum.EnumType'>")):
+
             enumValues = inspect.getmembers(classdefinition)
-            enumValues = [item for item in enumValues if (not item[0].startswith('_') and item[0] not in ['name', 'value'])]
+            enumValues = [item for item in enumValues if (
+                not item[0].startswith('_') and
+                item[0] not in ['name', 'value'])]
             keys = [x[0] for x in enumValues]
             values = [x[1] for x in enumValues]
-            result.append({'name':name, 'keys':keys, 'values':values})
+
+            attribute_docs = {}
+            if hasattr(module, '__file__') and module.__file__:
+                with open(module.__file__, 'r') as f:
+                    source = f.read()
+
+                tree = ast.parse(source)
+
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.ClassDef) and node.name == name:
+                        for i, item in enumerate(node.body):
+                            if isinstance(item, ast.Assign):
+                                for target in item.targets:
+                                    if isinstance(target, ast.Name):
+                                        attr_name = target.id
+
+                                        next_idx = i + 1
+                                        has_docstring = (
+                                            next_idx < len(node.body) and
+                                            isinstance(node.body[next_idx],
+                                                       ast.Expr) and
+                                            isinstance(
+                                                node.body[next_idx].value,
+                                                ast.Constant) and
+                                            isinstance(
+                                                node.body[next_idx]
+                                                .value.value, str))
+
+                                        if has_docstring:
+                                            next_node = node.body[next_idx]
+                                            docstring = next_node.value.value
+                                            attribute_docs[attr_name] = (
+                                                inspect.cleandoc(docstring))
+                        break
+
+            enum_result = {
+                'name': name,
+                'keys': keys,
+                'values': values
+            }
+
+            if attribute_docs:
+                enum_result['attribute_docs'] = attribute_docs
+
+            result.append(enum_result)
     return result
+
 
 def getClassInfo(module):
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        constructorArgs=None
+        constructorArgs = None
         methods = []
-        # let's go through all the functions
-        for classmember in inspect.getmembers(classdefinition, inspect.isfunction):
+        for classmember in inspect.getmembers(classdefinition,
+                                              inspect.isfunction):
             methodName = classmember[0]
-            if methodName=='__init__':
+            if methodName == '__init__':
                 constructorArgs = argspecContent(classmember[1])
-            elif (not methodName.startswith("_")) and classmember[1].__module__==classdefinition.__module__:
-                # this is a non-private, non-inherited function defined in the class
-                methodArgs = argspecContent(classmember[1])
-                methodDescription = getCleanedDoc(classmember[1])
-                methods.append({'name':methodName, 'doc':methodDescription, 'args':methodArgs})
+            elif (not methodName.startswith("_")) and (
+                classmember[1].__module__ == classdefinition.__module__ or
+                is_method_from_protocol(classmember[1], classdefinition)
+            ):
+                if is_async_to_sync_wrapper(classmember[1]):
+                    protocol_args, protocol_doc = find_protocol_method_info(
+                        methodName, classdefinition)
+                    if protocol_args is not None and protocol_doc is not None:
+                        methodArgs = protocol_args
+                        methodDescription = protocol_doc
+                    else:
+                        methodArgs = argspecContent(classmember[1])
+                        methodDescription = getCleanedDoc(
+                            classmember[1], class_context=classdefinition)
+                else:
+                    methodArgs = argspecContent(classmember[1])
+                    methodDescription = getCleanedDoc(
+                        classmember[1], class_context=classdefinition)
+
+                methods.append({'name': methodName,
+                                'doc': methodDescription,
+                                'args': methodArgs})
         if constructorArgs is None:
             continue
         cleaneddoc = getCleanedDoc(classdefinition)
-        # insert the constructor itself as the first thing in the list
-        methods.insert(0, {'name':name, 'doc':cleaneddoc, 'args':constructorArgs})
-        result.append({'name':name, 'constructorArgs':constructorArgs, 'doc':cleaneddoc, 'methods':methods})
+        methods.insert(
+            0, {'name': name, 'doc': cleaneddoc, 'args': constructorArgs})
+        result.append({'name': name, 'constructorArgs': constructorArgs,
+                      'doc': cleaneddoc, 'methods': methods})
     return result
 
+
+def is_async_to_sync_wrapper(method_func):
+    """
+    Check if a method is an async_to_sync wrapper by examining its module,
+    qualname, and docstring.
+    """
+    if (not hasattr(method_func, '__module__') or
+            not hasattr(method_func, '__qualname__')):
+        return False
+
+    if 'synapseclient.core.async_utils' not in method_func.__module__:
+        return False
+
+    if 'async_to_sync' in method_func.__qualname__:
+        return True
+
+    doc = inspect.getdoc(method_func)
+    if doc and 'The new method that will replace the non-async method' in doc:
+        return True
+
+    return False
+
+
+def find_protocol_method_info(method_name, class_definition):
+    """
+    Find the protocol method information for a given method name in the
+    class hierarchy.
+    Returns a tuple of (args_info, docstring) or (None, None) if not found.
+    """
+    if Protocol is None:
+        return None, None
+
+    for base_class in class_definition.__mro__:
+        if base_class is class_definition or base_class is object:
+            continue
+
+        is_protocol_class = issubclass(base_class, Protocol)
+
+        if is_protocol_class:
+            if (hasattr(base_class, '__module__') and
+                    base_class.__module__ and
+                    'mixins' in base_class.__module__):
+                continue
+
+            if (method_name in base_class.__dict__ and
+                    callable(getattr(base_class, method_name, None))):
+                protocol_method = getattr(base_class, method_name)
+                protocol_doc = inspect.getdoc(protocol_method)
+
+                if (protocol_doc and
+                        ('The new method that will replace the ' +
+                         'non-async method') not in protocol_doc):
+                    protocol_args = argspecContent(protocol_method)
+                    return protocol_args, protocol_doc
+
+    return None, None

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -25,4 +25,6 @@ generateRdFiles(srcRootDir,
                 classFilter = .synapseModelClassFilter,
                 keepContent = TRUE,
                 functionPrefix = "syn",
-                generateFunctionalInterface = TRUE)
+                generateFunctionalInterface = TRUE,
+                functionNameMapping = .synapseClientModelsMapping()
+                )

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -11,23 +11,18 @@ source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
 
 reticulate::py_run_string("import sys")
 reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(srcRootDir, "inst", "python")))
-## all functions in synapseclient.Synapse module
+
 generateRdFiles(srcRootDir,
                 pyPkg = "synapseclient",
                 container = "synapseclient.Synapse",
                 functionFilter = .synapseClassFunctionFilter,
-                functionPrefix = "syn")
-## all classes in synapseclient module
+                functionPrefix = "syn",
+                generateFunctionalInterface = TRUE)
 generateRdFiles(srcRootDir,
-                pyPkg = "synapseclient",
-                container = "synapseclient",
-                functionFilter = .removeAllFunctionsFunctionFilter,
-                classFilter = .synapseClientClassFilter,
-                keepContent = TRUE)
-# cherry pick Table function
-generateRdFiles(srcRootDir,
-                pyPkg = "synapseclient",
-                container = "synapseclient.table",
-                functionFilter = .cherryPickTableFunctionFilter,
-                classFilter = .removeAllClassesClassFilter,
-                keepContent = TRUE)
+                pyPkg = "synapseclient.models",
+                container = "synapseclient.models",
+                functionFilter = .removeAsyncFunctionFilter,
+                classFilter = .synapseModelClassFilter,
+                keepContent = TRUE,
+                functionPrefix = "syn",
+                generateFunctionalInterface = TRUE)

--- a/tools/installPythonClient.R
+++ b/tools/installPythonClient.R
@@ -5,7 +5,7 @@
 # Author: bhoff
 ###############################################################################
 
-PYTHON_CLIENT_VERSION <- '4.4.0'
+PYTHON_CLIENT_VERSION <- '4.8.0'
 
 args <- commandArgs(trailingOnly = TRUE)
 baseDir<-args[1]
@@ -19,5 +19,5 @@ print("*** Using Python Configuration:")
 reticulate::py_config()
 reticulate::py_run_string("import sys")
 reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(baseDir, "inst", "python")))
-reticulate::py_install(c("pandas>=1.5,<=2.0.3", "jinja2", "markupsafe","numpy<=1.24.4"))
+reticulate::py_install(c("pandas>=1.5", "jinja2", "markupsafe", "numpy>=1.24.0"))
 reticulate::py_install(c(paste("synapseclient==", PYTHON_CLIENT_VERSION, sep="")), pip=T)


### PR DESCRIPTION
# **Problem:**

- The now legacy Synapse python Client requires that the R-interface use specific versions of packages like rjson, reticulate, and R. This leads to significant barriers when using the R client within a larger environment requiring the need to carefully juggle versions of packages.
- The new `models` interface of the SYNPY client is not yet exposed to the R-client

# **Solution:**

- Enhance synapser package functionality and documentation
- Updated .gitignore to exclude launch.json.
- Added Bryan Fauble as an author in DESCRIPTION.
- Refined dependency specifications in DESCRIPTION for reticulate and rjson.
- Introduced new functions to define class methods and functional interfaces for Python classes in R.
- Enhanced auto-generation of R wrappers for Python classes, including support for functional interfaces.
- Improved documentation generation for functional interface functions.
- Cleaned up shared utility functions and removed deprecated code.
- Updated Python client version to 4.8.0 and adjusted package installation requirements.
- Refactored gateway.py to improve generator handling and annotations.
- Enhanced pyPkgInfo.py to support protocol method detection and documentation extraction.
- Streamlined createRdFiles.R to generate documentation for both Synapse and models.

# **Testing:**

- See [this Gist for an example](https://gist.github.com/BryanFauble/a27a9f49b3931107f559918d21c1d324) that was tested with this code after installing [this branch](https://github.com/Sage-Bionetworks/synapsePythonClient/pull/1210)
