### PR TITLE
[SYNR-1541] Patching for rjson version ranges resolving from remotes install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,18 +14,18 @@ Description: Provides R language bindings for Synapse RESTful web services.
 Encoding: UTF-8
 License: Apache License 2.0
 Imports:
-  reticulate (>= 1.25),
-  reticulate (< 1.29),
+  reticulate(>= 1.25),
+  reticulate(<= 1.28),
   methods,
-  rjson (< 0.2.22),
+  rjson(<= 0.2.21),
   stats,
   utils
 Depends:
   R(>= 4.1.3),
   R(< 4.5)
 Remotes:
-  rstudio/reticulate@v1.28,
-  cran/rjson@0.2.21
+  reticulate@1.28,
+  rjson@0.2.21
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,18 +14,18 @@ Description: Provides R language bindings for Synapse RESTful web services.
 Encoding: UTF-8
 License: Apache License 2.0
 Imports:
-  reticulate(>= 1.25),
-  reticulate(<= 1.28),
+  reticulate (>= 1.25),
+  reticulate (< 1.29),
   methods,
-  rjson(<= 0.2.21),
+  rjson (< 0.2.22),
   stats,
   utils
 Depends:
   R(>= 4.1.3),
   R(< 4.5)
 Remotes:
-  reticulate@1.28,
-  rjson@0.2.21
+  rstudio/reticulate@v1.28,
+  cran/rjson@0.2.21
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ Depends:
   R(>= 4.1.3),
   R(< 4.5)
 Remotes:
-  reticulate@1.28,
-  rjson@0.2.21
+  rstudio/reticulate@v1.28,
+  cran/rjson@0.2.21
 Suggests: pack, R6, testthat, knitr, rmarkdown
 URL: https://www.synapse.org
 VignetteBuilder: knitr


### PR DESCRIPTION
# **Problem:**

- When installing the synapser package the DESCRIPTION file was not taking into account the maximum version of the `rjson` dependency, causing the following command to install the latest `rjson` package:

```
    result <- remotes::install_cran(
        "synapser", 
        repos = c("http://ran.synapse.org", "https://cloud.r-project.org"),
    )
```

# **Solution:**

- Specify version ranges in a slightly different way that appears to be compliant.

# **Testing:**

- I verified that I could install `synapser` WITHOUT rjson already having been installed via both of the following:

```
    result <- remotes::install_local(
        path=".",
        upgrade = "never",
    )
```

```
    result <- remotes::install_local(
        path=".",
        upgrade = "always",
    )
```

```
    result <- remotes::install_local(
        path=".",
        upgrade = "always",
        force = TRUE,
    )
```

Console logs of install:

```
─ R CMD build ─────────────────────────────────────────────────────────────────
* checking for file ‘/tmp/RtmpkhkEtB/remotesb033e23fa70eb/cran-rjson-4e2442a/DESCRIPTION’ ... OK
* preparing ‘rjson’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
* checking vignette meta-information ... OK
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building ‘rjson_0.2.21.tar.gz’

Installing package into ‘/home/ec2-user/R/x86_64-pc-linux-gnu-library/4.3’
(as ‘lib’ is unspecified)
* installing *source* package ‘rjson’ ...
** using staged installation
** libs
using C compiler: ‘gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5)’
using C++ compiler: ‘g++ (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5)’
installing to /home/ec2-user/R/x86_64-pc-linux-gnu-library/4.3/00LOCK-rjson/00new/rjson/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (rjson)
Downloading GitHub repo cran/rjson@0.2.21
Skipping rjson, it is already being installed
── R CMD build ─────────────────────────────────────────────────────────────────
* checking for file ‘/tmp/RtmpkhkEtB/fileb033e7607bd53/synapser/DESCRIPTION’ ... OK
* preparing ‘synapser’:
* checking DESCRIPTION meta-information ... OK
* running ‘cleanup’
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building ‘synapser_2.1.1.tar.gz’

Installing package into ‘/home/ec2-user/R/x86_64-pc-linux-gnu-library/4.3’
(as ‘lib’ is unspecified)
* installing *source* package ‘synapser’ ...
** using staged installation
+ '/home/ec2-user/.virtualenvs/r-reticulate-4/bin/python' -m pip install --upgrade --no-user 'pandas>=1.5,<=2.0.3' 'jinja2' 'markupsafe' 'numpy<=1.24.4'
+ '/home/ec2-user/.virtualenvs/r-reticulate-4/bin/python' -m pip install --upgrade --no-user 'synapseclient==4.4.0'
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (synapser)
* ```