### PR TITLE
[SYNR-1600, SYNR-1606] implement instance first with pipe interface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ Add method names here to suppress them from the generated R wrappers.
 
 ## Updating the Python Client Version
 
-The wrapped Python client version is pinned in `R/zzz.R` and `tools/installPythonClient.R`:
+The wrapped Python client version is pinned in `R/shared.R`:
 
 ```r
 PYTHON_CLIENT_VERSION <- 'v4.12'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,324 @@
+# Contributing to synapser
+
+This guide covers development, documentation, and release practices for the [synapser](https://github.com/Sage-Bionetworks/synapser) R package, which wraps the [Synapse Python client](https://github.com/Sage-Bionetworks/synapsePythonClient).
+
+---
+
+## Repository
+
+- **synapser**: https://github.com/Sage-Bionetworks/synapser
+- **synapserutils**: https://github.com/Sage-Bionetworks/synapserutils
+
+### Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `master` | Latest release |
+| `develop` | Active development |
+| `vX.Y-rc` | Release candidate for version X.Y |
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- R (check `DESCRIPTION` for minimum version)
+- Python (for the embedded Python client)
+- `devtools`, `pkgdown`, `styler` R packages
+
+### Configuration
+
+Create `~/.synapseConfig` for Synapse credentials:
+
+```ini
+[authentication]
+authtoken=your_personal_access_token
+```
+
+An example config is at https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseclient/.synapseConfig.
+
+### Create a Feature Branch
+
+1. Checkout a new branch from `develop`:
+   ```bash
+   git checkout develop
+   git pull
+   git checkout -b SYNR-1234-short-description
+   ```
+3. On your branch, add these repository secrets (values in LastPass under "Python Client dev stack openssl keys") to enable vignette integration tests in GitHub Actions:
+   - `encrypted_d17283647768_iv`
+   - `encrypted_d17283647768_key`
+
+---
+
+## Making Changes
+
+### Code Style
+
+Follow [tidyverse style guidelines](http://style.tidyverse.org/). Format files before committing:
+
+```r
+styler::style_file("R/your_file.R")
+```
+
+You can also utilize `Air - R Language Support` extension from VS code or cursor to allow Air to format R code on save for you. 
+
+### Submitting a Pull Request
+
+Push your branch to your feature branch:
+
+```bash
+git push --set-upstream origin SYNR-1234-short-description
+```
+
+When your change is ready for review:
+
+- Open a Pull Request from your branch to `develop` in `Sage-Bionetworks/synapser`.
+- Request review from the DPE team or a designated reviewer.
+- After approval and passing checks, merge into `develop`.
+
+
+## Adding New Models or Functions
+
+When the underlying Python client adds new model classes or top-level functions that should be exposed in synapser, update the corresponding allowlists and mappings in `R/shared.R`. 
+
+### 1. Whitelist new model classes — `.modelClassesToInclude`
+
+`R/shared.R` contains a character vector that controls which Python model classes get wrapped as R functions:
+
+```r
+.modelClassesToInclude <- c(
+  "Agent",
+  "AgentSession",
+  "Project",
+  "Folder",
+  "File",
+  # ... etc.
+)
+```
+
+Add the exact Python class name (case-sensitive, matching `synapseclient.models`) to this vector. Classes omitted here will not be wrapped. Classes that are commented out are intentionally excluded.
+
+### 2. Whitelist new operations functions — `.operationsFunctionNames`
+
+`R/shared.R` also contains an allowlist for synchronous functions exposed from `synapseclient.operations`:
+
+```r
+.operationsFunctionNames <- c(
+  "get",
+  "store",
+  "delete",
+  "download_list_files",
+  # ... etc.
+)
+```
+
+Add the exact Python function name (case-sensitive) to this vector when you want it wrapped into `syn*` R functions. 
+
+### 3. Whitelist legacy Synapse functions — `.synapseClassMethodsToInclude`
+
+Some wrappers are generated from the legacy `synapseclient.Synapse` class:
+
+```r
+.synapseClassMethodsToInclude <- c(
+  "login",
+  "logout",
+  "setEndpoints",
+  "sendMessage",
+  "rest_get_async",
+  # ... etc.
+)
+```
+
+### 4. Add function name mappings — `.functionNameMappingSynapse` and `.functionNameMappingSynapseclientModels`
+
+By default, Python method names are converted to R function names using a `syn` prefix (for example, `store` -> `synStore`). Use these mapping helpers in `R/shared.R` when the generated name should be renamed for clarity:
+
+- `.functionNameMappingSynapse`: for methods from `synapseclient.Synapse`
+- `.functionNameMappingSynapseclientModels`: for methods from `synapseclient.models`
+
+Example mappings:
+
+```r
+.functionNameMappingSynapse <- function() {
+  list(
+    explicit = list(
+      "synRestGetAsync" = "synRestGet",
+   # ... etc.
+    )
+  )
+}
+
+.functionNameMappingSynapseclientModels <- function() {
+  list(
+    explicit = list(
+      # "auto-generated R name" = "desired R name"
+      "synDisassociateFromEntity" = "synDisassociateActivityFromEntity",
+      "synFromPath"               = "synGetFromPath",
+      # ... etc.
+    )
+  )
+}
+```
+
+Add a new `"auto-generated-name" = "desired-name"` entry under the appropriate mapping function for any method whose default R name should be overridden.
+
+### 5. Exclude specific methods — `.modelClassMethodsToOmit`
+
+Methods from `synapseclient.models` that are internal or not useful in R (e.g., `fill_from_dict`, `to_synapse_request`) are listed in:
+
+```r
+.modelClassMethodsToOmit <- c(
+  "format_for_manifest",
+  "fill_from_dict",
+  "to_synapse_request",
+  "allow_client_caching"
+)
+```
+
+Add method names here to suppress them from the generated R wrappers.
+
+---
+
+## Updating the Python Client Version
+
+The wrapped Python client version is pinned in `R/zzz.R` and `tools/installPythonClient.R`:
+
+```r
+PYTHON_CLIENT_VERSION <- 'v4.12'
+```
+
+After bumping the version, regenerate documentation (see next section).
+
+---
+
+## Regenerating Documentation (This part is subject to change.)
+
+synapser auto-generates draft `.Rd` files from Python docstrings into `auto-man/`. These must be manually reviewed and merged into `man/` before committing.
+
+1. Build the package to regenerate `auto-man/`:
+   ```bash
+   R CMD INSTALL .
+   ```
+
+2. Diff the auto-generated files:
+   ```bash
+   git diff auto-man/
+   ```
+
+3. Manually copy new or changed files from `auto-man/` to `man/`, editing as needed:
+   - Translate Python code examples into R equivalents.
+   - Verify parameter descriptions are accurate for R callers.
+
+4. Commit both `auto-man/` and `man/` changes:
+   ```bash
+   git add auto-man/ man/
+   git commit -m "SYNR-1234: update generated and curated docs for new FooClass wrapper"
+   ```
+
+> **Note:** Do not skip the manual review step — Python docstrings often contain Python-specific syntax that renders incorrectly in R documentation.
+
+---
+
+## Release Process
+
+### Step 1: Identify scope
+
+Review open [SYNR JIRA tickets](https://sagebionetworks.jira.com/projects/SYNR/issues), set the target version, and assign tickets. All feature work merges to `develop` via Pull Requests (see above).
+
+### Step 2: Staging release
+
+Once all tickets for the release are resolved:
+
+1. Create a release candidate branch from `develop`:
+   ```bash
+   git checkout -b vX.Y-rc develop
+   ```
+
+2. Update `NEWS.md` (changelog) and bump the version in `DESCRIPTION`.
+
+3. Build the pkgdown site:
+   ```bash
+   R -e "devtools::build_readme()"
+   R -e "pkgdown::build_site()"
+   ```
+   Review `docs/index.html`, then commit and push.
+
+4. On GitHub → [Releases](https://github.com/Sage-Bionetworks/synapser/releases), draft a new release:
+   - **Tag**: `X.Y-rc`
+   - **Target**: `vX.Y-rc` branch
+   - **Title**: `X.Y-rc`
+   - **Check** "Set as a pre-release"
+
+   Publishing triggers a GitHub Action that deploys to http://staging-ran.synapse.org.
+
+5. Notify validators with the artifact version (format: `<version>.<build-number>`, e.g. `1.0.87`).
+
+### Step 3: Validation
+
+Validators install from staging RAN:
+
+```r
+install.packages("synapser", repos = c("http://staging-ran.synapse.org"))
+```
+
+Or via devtools:
+
+```r
+devtools::install_github("Sage-Bionetworks/synapser@v2.0-rc")
+```
+
+### Step 4: Patch staging (if needed)
+
+For critical bugs found during validation:
+1. Fix on a branch off `vX.Y-rc`, open a PR back to `vX.Y-rc`.
+2. After merge, publish a new pre-release (repeat Step 2 steps 4–5).
+3. Notify validators to re-test and re-validate the ticket with the new artifact.
+
+### Step 5: Production release
+
+Once all tickets are closed:
+
+1. On GitHub → Releases, draft a new release:
+   - **Tag**: `X.Y`
+   - **Target**: `vX.Y-rc` branch
+   - **Title**: `X.Y`
+   - **Do NOT** check "This is a pre-release"
+
+   Publishing deploys to http://ran.synapse.org.
+
+2. Merge the release candidate to `master`:
+   ```bash
+   git checkout master
+   git merge vX.Y-rc
+   git push upstream master
+   ```
+   Merging to `master` automatically updates https://r-docs.synapse.org via GitHub Pages.
+
+3. Merge `master` back to `develop`:
+   ```bash
+   git checkout develop
+   git merge master
+   git push upstream develop
+   ```
+
+## Publishing Documentation
+
+Users discover `synapser` through several entry points:
+
+1. Synapse Docs portal: https://r-docs.synapse.org/
+2. GitHub repository: https://github.com/Sage-Bionetworks/synapser
+3. Staging RAN: http://staging-ran.synapse.org
+4. Production RAN: http://ran.synapse.org
+
+Each location should include general `synapser` information and installation guidance. The package documentation site should be the canonical source for full documentation, and the other locations should link to it.
+
+Documentation updates are part of the release process:
+
+- During staging release builds (artifact publication to staging RAN), regenerate docs and commit updates to the release candidate branch.
+- During production release, merge the release candidate branch to `master`; this updates the published docs site.
+
+## CI/CD
+
+GitHub Actions drive all builds and deployments. The workflow is defined in [`.github/workflows/build.yml`](https://github.com/Sage-Bionetworks/synapser/blob/develop/.github/workflows/build.yml). Every push to a fork runs the build and test suite automatically.

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -516,8 +516,10 @@ defineFunction <- function(
   functionContainerName,
   pyParams,
   setGenericCallback,
-  transformReturnObject = NULL
+  transformReturnObject = NULL,
+  functionNameMapping = NULL
 ) {
+  rName <- applyFunctionNameMapping(rName, functionNameMapping)
   force(rName)
   force(pyName)
   force(functionContainerName)
@@ -574,7 +576,8 @@ defineFunction <- function(
 autoGenerateFunctions <- function(
   setGenericCallback,
   functionInfo,
-  transformReturnObject = NULL
+  transformReturnObject = NULL,
+  functionNameMapping = NULL
 ) {
   for (f in functionInfo) {
     defineFunction(
@@ -583,7 +586,8 @@ autoGenerateFunctions <- function(
       f$functionContainerName,
       f$args,
       setGenericCallback,
-      transformReturnObject
+      transformReturnObject,
+      functionNameMapping
     )
   }
 }
@@ -1005,7 +1009,8 @@ generateRWrappers <- function(
   autoGenerateFunctions(
     setGenericCallback,
     functionInfo,
-    transformReturnObject
+    transformReturnObject,
+    functionNameMapping
   )
 
   if (generateFunctionalInterface && !is.null(functionPrefix)) {
@@ -1644,7 +1649,7 @@ writeContent <- function(content, name, targetFolder) {
 #'   container = "pyPackageName.aModuleInPyPackageName",
 #'   classFilter = myclassFilter)
 #'
-#' # 4. Generate docs including functional interface functions (e.g., synDatasetGet, synProjectStore)
+#' # 4. Generate docs including functional interface functions (e.g.,synGetAcl(instance,...)
 #' generateRdFiles(
 #'   srcRootDir = "path/to/R/pkg",
 #'   pyPkg = "pyPackageName",

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -692,7 +692,7 @@ determineArgsAndKwArgs <- function(...) {
 
 .replaceAuthMessage <- function(text) {
   gsub(
-    "You have not provided valid credentials.*?for more information\\.",
+    "(?s)You have not provided valid credentials.*?for more information\\.",
     .rAuthMessage,
     text,
     perl = TRUE
@@ -706,7 +706,7 @@ cleanUpStackTrace <- function(callable, args) {
     result <- do.call(callable, args)
     sink()
     close(conn)
-    cat(.replaceAuthMessage(paste(outputCapture, collapse = "")))
+    cat(paste(outputCapture, collapse = ""))
     result
   },
   error = function(e) {

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -13,8 +13,7 @@
 # The inner worker function is a function that takes an instance and ... as arguments and calls the Python method on the instance.
 # Example:
 # .functionalMethodDispatch
-#  ├── synGetAcl_File      → function(instance, ...) # calls the Python method on the instance
-#  ├── synGetAcl_Project   → function(instance, ...) # calls the Python method on the instance
+#  ├── synGetAcl      → function(instance, ...) # calls the Python method on the instance
 #  └── ...
 #
 .functionalMethodDispatch <- new.env(parent = emptyenv())
@@ -79,6 +78,7 @@ defineEnum <- function(assignEnumCallback, name, keys, values) {
     lastEmpty <- nArgs - nDefs
 
     ## Add the defaults to the end
+    ## The key assumption is that Python defaults belong to the last N arguments
     newArgs[(lastEmpty + 1):nArgs] <- defaults
   }
 
@@ -219,6 +219,7 @@ defineClassMethod <- function(
   newArgs <- .createFormalArgs(pyParams)
   if (length(newArgs) > 0) {
     # Remove 'self' from arguments if it exists and add 'instance' as first parameter
+    ## TODO: to revisit when working on https://sagebionetworks.jira.com/browse/SYNR-1602 to strip out synapse_client arguments from the method signature
     if (!is.null(newArgs) && "self" %in% names(newArgs)) {
       newArgs <- newArgs[names(newArgs) != "self"]
     }
@@ -253,11 +254,11 @@ defineClassMethod <- function(
 #      it errors with "No '<genericName>' method registered for class '<className>'".
 #   5. For static methods (isStatic = TRUE) no inner worker is registered; instead a
 #      plain function is created that resolves the Python class at call time via
-#      reticulate::py_eval and invokes the method directly without an instance.
+#      reticulate::py_eval and invokes the method directly on the class.
 #
 # @param module the Python module path (e.g. "synapseclient.models")
 # @param className the Python class name (e.g. "File"); used as the dispatch key suffix
-# @param methodName the method name used to derive the R function name (snake_case or camelCase)
+# @param methodName the method name used to derive the R function name (snake_case)
 # @param pyParams parameter info list from getFunctionInfo: args, defaults, varargs, keywords
 # @param pythonMethodName the original Python method name if it differs from methodName; defaults to methodName
 # @param functionPrefix prefix prepended to the camelCase method name (default "syn")
@@ -305,7 +306,12 @@ defineFunctionalClassMethod <- function(
   if (isStatic) {
     # Static methods: no instance — call directly on the Python class.
     if (!exists(genericName, mode = "function", inherits = FALSE)) {
-      staticFn <- function(...) {
+      # Private wrapper with plain (...) so all named args reach determineArgsAndKwArgs.
+      # The public staticFn below has named formals; if it used (...) directly,
+      # named formals would absorb the args before they reach ... in the body.
+      staticWrapperName <- paste0(".", genericName)
+      force(staticWrapperName)
+      assign(staticWrapperName, function(...) {
         pyClass <- reticulate::py_eval(sprintf("%s.%s", module, className))
         argsAndKwArgs <- determineArgsAndKwArgs(...)
         returnedObject <- cleanUpStackTrace(
@@ -323,6 +329,16 @@ defineFunctionalClassMethod <- function(
           class(returnedObject)[1] <- "CsvFileTable"
         }
         returnedObject
+      })
+
+      # Public function: named formals for discoverability; sys.call() forwards
+      # all args (including named ones) to the private wrapper.
+      wn <- staticWrapperName
+      staticFn <- function(...) {
+        call <- sys.call()
+        call[[1]] <- as.name('list')
+        dots <- eval.parent(call)
+        do.call(wn, args = dots)
       }
 
       methodArgs <- .createFormalArgs(pyParams)
@@ -359,7 +375,7 @@ defineFunctionalClassMethod <- function(
     returnedObject
   }
 
-  # Assign the inner worker function to the dispatch table under the key "<genericName>_<className>"
+  # Assign the classMethodFn to the dispatch table under the key "<genericName>_<className>"
   assign(classMethodKey, classMethodFn, envir = .functionalMethodDispatch)
 
   # Register the generic once as a plain function
@@ -368,7 +384,7 @@ defineFunctionalClassMethod <- function(
     tbl <- .functionalMethodDispatch
     genericFn <- function(instance, ...) {
       # sys.call() captures the raw call so named formals (e.g. comment, label)
-      # are forwarded to the inner worker
+      # are forwarded to the classMethodFn
       call <- sys.call()
       call[[1]] <- as.name('list')
       dots <- eval.parent(call)
@@ -436,8 +452,7 @@ autoGenerateClassesWithFunctionalInterface <- function(
   setGenericCallback,
   classInfo,
   functionPrefix = "syn",
-  functionNameMapping = NULL,
-  verbose = FALSE
+  functionNameMapping = NULL
 ) {
   for (c in classInfo) {
     # suppress output when loading package
@@ -452,8 +467,7 @@ autoGenerateClassesWithFunctionalInterface <- function(
         # Skip the constructor method (it has the same name as the class)
         if (method$name != c$name) {
           isStatic <- isTRUE(method$is_static)
-          # Create both regular class method and functional interface
-          #defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
+          # Create functional interface
           defineFunctionalClassMethod(
             module,
             c$name,

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -22,7 +22,9 @@
 # Lazily cached gateway module — imported once, reused everywhere.
 .gateway <- NULL
 .getGateway <- function() {
-  if (is.null(.gateway)) .gateway <<- reticulate::import("gateway")
+  if (is.null(.gateway)) {
+    .gateway <<- reticulate::import("gateway")
+  }
   .gateway
 }
 
@@ -65,7 +67,7 @@ defineEnum <- function(assignEnumCallback, name, keys, values) {
     argNames <- argNames[-1]
   }
 
-  newArgs <- setNames(rep(list(quote(expr =)), length(argNames)), argNames)
+  newArgs <- setNames(rep(list(quote(expr = )), length(argNames)), argNames)
 
   if (length(defaults) > 0) {
     ## Otherwise fill in arguments with defaults at the end, and add empty symbols
@@ -83,7 +85,7 @@ defineEnum <- function(assignEnumCallback, name, keys, values) {
   if (!is.null(pyParams$varargs) || !is.null(pyParams$keywords)) {
     # if the Python signature uses *args or **kwargs we add
     # dots to the R signature to match
-    newArgs <- append(newArgs, alist(... =))
+    newArgs <- append(newArgs, alist(... = ))
   }
 
   return(newArgs)
@@ -157,7 +159,14 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
 #   args, defaults, varargs, keywords
 # @param pythonMethodName actual Python method name passed to gateway$invoke; defaults
 #   to methodName when NULL — set this when the R name and Python name differ
-defineClassMethod <- function(module, setGenericCallback, className, methodName, pyParams, pythonMethodName = NULL) {
+defineClassMethod <- function(
+  module,
+  setGenericCallback,
+  className,
+  methodName,
+  pyParams,
+  pythonMethodName = NULL
+) {
   force(className)
   force(methodName)
   force(module)
@@ -213,9 +222,9 @@ defineClassMethod <- function(module, setGenericCallback, className, methodName,
     if (!is.null(newArgs) && "self" %in% names(newArgs)) {
       newArgs <- newArgs[names(newArgs) != "self"]
     }
-    newArgs <- append(newArgs, list(instance = quote(expr =)), after = 0)
+    newArgs <- append(newArgs, list(instance = quote(expr = )), after = 0)
   } else {
-    newArgs <- list(instance = quote(expr =))
+    newArgs <- list(instance = quote(expr = ))
   }
 
   formals(rFn) <- newArgs
@@ -254,7 +263,16 @@ defineClassMethod <- function(module, setGenericCallback, className, methodName,
 # @param functionPrefix prefix prepended to the camelCase method name (default "syn")
 # @param functionNameMapping optional list with an $explicit named character vector for overriding generated names
 # @param isStatic if TRUE, registers a static wrapper that omits the instance argument
-defineFunctionalClassMethod <- function(module, className, methodName, pyParams, pythonMethodName = NULL, functionPrefix = "syn", functionNameMapping = NULL, isStatic = FALSE) {
+defineFunctionalClassMethod <- function(
+  module,
+  className,
+  methodName,
+  pyParams,
+  pythonMethodName = NULL,
+  functionPrefix = "syn",
+  functionNameMapping = NULL,
+  isStatic = FALSE
+) {
   # Capture the package namespace NOW, before any nested calls.
   # sys.function() here = defineFunctionalClassMethod; its environment = the package namespace.
   # Inside local({}) or any nested call, sys.function() would return a different function
@@ -290,13 +308,20 @@ defineFunctionalClassMethod <- function(module, className, methodName, pyParams,
       staticFn <- function(...) {
         pyClass <- reticulate::py_eval(sprintf("%s.%s", module, className))
         argsAndKwArgs <- determineArgsAndKwArgs(...)
-        returnedObject <- cleanUpStackTrace(gateway$invoke, list(
-          method = list(pyClass, pythonMethodName),
-          args   = argsAndKwArgs$args,
-          kwargs = argsAndKwArgs$kwargs
-        ))
-        if (grepl("GeneratorWrapper", class(returnedObject)[1])) class(returnedObject)[1] <- "GeneratorWrapper"
-        if (grepl("CsvFileTable", class(returnedObject)[1])) class(returnedObject)[1] <- "CsvFileTable"
+        returnedObject <- cleanUpStackTrace(
+          gateway$invoke,
+          list(
+            method = list(pyClass, pythonMethodName),
+            args = argsAndKwArgs$args,
+            kwargs = argsAndKwArgs$kwargs
+          )
+        )
+        if (grepl("GeneratorWrapper", class(returnedObject)[1])) {
+          class(returnedObject)[1] <- "GeneratorWrapper"
+        }
+        if (grepl("CsvFileTable", class(returnedObject)[1])) {
+          class(returnedObject)[1] <- "CsvFileTable"
+        }
         returnedObject
       }
 
@@ -317,13 +342,20 @@ defineFunctionalClassMethod <- function(module, className, methodName, pyParams,
   # by name in any namespace — retrieved only by the generic at dispatch time.
   classMethodFn <- function(instance, ...) {
     argsAndKwArgs <- determineArgsAndKwArgs(...)
-    returnedObject <- cleanUpStackTrace(gateway$invoke, list(
-      method = list(instance, pythonMethodName),
-      args   = argsAndKwArgs$args,
-      kwargs = argsAndKwArgs$kwargs
-    ))
-    if (grepl("GeneratorWrapper", class(returnedObject)[1])) class(returnedObject)[1] <- "GeneratorWrapper"
-    if (grepl("CsvFileTable", class(returnedObject)[1])) class(returnedObject)[1] <- "CsvFileTable"
+    returnedObject <- cleanUpStackTrace(
+      gateway$invoke,
+      list(
+        method = list(instance, pythonMethodName),
+        args = argsAndKwArgs$args,
+        kwargs = argsAndKwArgs$kwargs
+      )
+    )
+    if (grepl("GeneratorWrapper", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "GeneratorWrapper"
+    }
+    if (grepl("CsvFileTable", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "CsvFileTable"
+    }
     returnedObject
   }
 
@@ -332,7 +364,7 @@ defineFunctionalClassMethod <- function(module, className, methodName, pyParams,
 
   # Register the generic once as a plain function
   if (!exists(genericName, mode = "function", inherits = TRUE)) {
-    gn  <- genericName
+    gn <- genericName
     tbl <- .functionalMethodDispatch
     genericFn <- function(instance, ...) {
       # sys.call() captures the raw call so named formals (e.g. comment, label)
@@ -341,7 +373,10 @@ defineFunctionalClassMethod <- function(module, className, methodName, pyParams,
       call[[1]] <- as.name('list')
       dots <- eval.parent(call)
       if (length(dots) == 0) {
-        stop(sprintf("Pass an object as the first argument, e.g. ClassName(...) |> %s()", gn))
+        stop(sprintf(
+          "Pass an object as the first argument, e.g. ClassName(...) |> %s()",
+          gn
+        ))
       }
       cls <- class(dots[[1]])[1]
       key <- paste0(gn, "_", cls)
@@ -356,7 +391,7 @@ defineFunctionalClassMethod <- function(module, className, methodName, pyParams,
     if (!"..." %in% names(methodArgs)) {
       methodArgs <- c(methodArgs, alist(... = ))
     }
-    formals(genericFn) <- c(list(instance = quote(expr =)), methodArgs)
+    formals(genericFn) <- c(list(instance = quote(expr = )), methodArgs)
     assign(genericName, genericFn, envir = pkgNs)
   }
 }
@@ -375,7 +410,14 @@ autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
       for (method in c$methods) {
         # Skip the constructor method (it has the same name as the class)
         if (method$name != c$name) {
-          defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
+          defineClassMethod(
+            module,
+            setGenericCallback,
+            c$name,
+            method$name,
+            method$args,
+            method$name
+          )
         }
       }
     }
@@ -389,12 +431,21 @@ autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
 # @param classInfo the classes to generate R wrappers for
 # @param functionPrefix the prefix to add to functional method names (e.g., "syn")
 # @param functionNameMapping the mapping configuration for customizing function names
-autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallback, classInfo, functionPrefix = "syn", functionNameMapping = NULL, verbose = FALSE) {
+autoGenerateClassesWithFunctionalInterface <- function(
+  module,
+  setGenericCallback,
+  classInfo,
+  functionPrefix = "syn",
+  functionNameMapping = NULL,
+  verbose = FALSE
+) {
   for (c in classInfo) {
     # suppress output when loading package
-    if (nzchar(Sys.getenv("R_INSTALL_PKG"))) cat(sprintf("Creating class wrapper for: %s\n", c$name))
+    if (nzchar(Sys.getenv("R_INSTALL_PKG"))) {
+      cat(sprintf("Creating class wrapper for: %s\n", c$name))
+    }
     defineConstructor(module, setGenericCallback, c$name, c$constructorArgs)
-    
+
     # Generate wrappers for class methods (excluding constructor)
     if (!is.null(c$methods)) {
       for (method in c$methods) {
@@ -403,7 +454,16 @@ autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallbac
           isStatic <- isTRUE(method$is_static)
           # Create both regular class method and functional interface
           #defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
-          defineFunctionalClassMethod(module, c$name, method$name, method$args, method$name, functionPrefix, functionNameMapping, isStatic = isStatic)
+          defineFunctionalClassMethod(
+            module,
+            c$name,
+            method$name,
+            method$args,
+            method$name,
+            functionPrefix,
+            functionNameMapping,
+            isStatic = isStatic
+          )
         }
       }
     }
@@ -436,12 +496,14 @@ autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallbac
 # @param transformReturnObject optional function applied to the Python return
 #   value before it is returned to the caller; use to reshape raw Python objects
 #   into R-friendly types (e.g. list to data frame). NULL means pass through unchanged.
-defineFunction <- function(rName,
-                           pyName,
-                           functionContainerName,
-                           pyParams,
-                           setGenericCallback,
-                           transformReturnObject = NULL) {
+defineFunction <- function(
+  rName,
+  pyName,
+  functionContainerName,
+  pyParams,
+  setGenericCallback,
+  transformReturnObject = NULL
+) {
   force(rName)
   force(pyName)
   force(functionContainerName)
@@ -495,9 +557,11 @@ defineFunction <- function(rName,
 # @param setGenericCallback the callback to setGeneric defined in the target R package
 # @param functionInfo the functions to generate R wrappers for
 # @param transformReturnObject optional function to change returned values in R
-autoGenerateFunctions <- function(setGenericCallback,
-                                  functionInfo,
-                                  transformReturnObject = NULL) {
+autoGenerateFunctions <- function(
+  setGenericCallback,
+  functionInfo,
+  transformReturnObject = NULL
+) {
   for (f in functionInfo) {
     defineFunction(
       f$rName,
@@ -529,7 +593,7 @@ snakeToCamel <- function(x) {
   sapply(
     strsplit(x, "_"),
     function(x) {
-      paste(capitalizeFirstLetter(x), collapse="")
+      paste(capitalizeFirstLetter(x), collapse = "")
     }
   )
 }
@@ -561,13 +625,18 @@ removeNulls <- function(x) {
 # @param functionFilter optional function to modify the returned functions
 # @param functionPrefix optional text to add to the name of the functions
 # @param pySingletonName optional singleton object in python
-getFunctionInfo <- function(pyPkg,
-                            module,
-                            functionFilter = NULL,
-                            functionPrefix = NULL,
-                            pySingletonName = NULL) {
+getFunctionInfo <- function(
+  pyPkg,
+  module,
+  functionFilter = NULL,
+  functionPrefix = NULL,
+  pySingletonName = NULL
+) {
   .initPyPkgInfo(pyPkg)
-  functionInfo <- reticulate::py_eval(sprintf("pyPkgInfo.getFunctionInfo(%s)", module))
+  functionInfo <- reticulate::py_eval(sprintf(
+    "pyPkgInfo.getFunctionInfo(%s)",
+    module
+  ))
 
   if (!is.null(functionFilter)) {
     functionInfo <- lapply(X = functionInfo, functionFilter)
@@ -619,7 +688,10 @@ getEnumInfo <- function(pyPkg, module, enumFilter = NULL) {
 # @param classFilter optional function to modify the returned classes
 getClassInfo <- function(pyPkg, module, classFilter = NULL) {
   .initPyPkgInfo(pyPkg)
-  classInfo <- reticulate::py_eval(sprintf("pyPkgInfo.getClassInfo(%s)", module))
+  classInfo <- reticulate::py_eval(sprintf(
+    "pyPkgInfo.getClassInfo(%s)",
+    module
+  ))
   if (!is.null(classFilter)) {
     classInfo <- lapply(X = classInfo, classFilter)
   }
@@ -645,9 +717,11 @@ determineArgsAndKwArgs <- function(...) {
   if (n > 0) {
     positionalArgument <- TRUE
     for (i in 1:n) {
-      if (is.null(valuenames) ||
-        length(valuenames[[i]]) == 0 ||
-        nchar(valuenames[[i]]) == 0) {
+      if (
+        is.null(valuenames) ||
+          length(valuenames[[i]]) == 0 ||
+          nchar(valuenames[[i]]) == 0
+      ) {
         # it's a positional argument
         if (!positionalArgument) {
           stop("positional argument follows keyword argument")
@@ -676,14 +750,6 @@ determineArgsAndKwArgs <- function(...) {
   list(args = args, kwargs = kwargs)
 }
 
-# The purpose of this function is to remove the Python stack trace from an error message
-#  generated when calling Python from R. This makes the command line response more readable
-#  when an error occurs. To support debugging the stack trace truncation can be overridden
-#  by setting the global option 'verbose' to TRUE.
-#
-# @param callable the function to be called
-# @param args the arguments to be passed to the function 'callable'
-# @return the result of calling the given function with the given arguments
 .rAuthMessage <- paste0(
   "You have not provided valid credentials for authentication with Synapse. ",
   "Please provide an authentication token and use `synLogin()` before your next attempt. ",
@@ -699,30 +765,40 @@ determineArgsAndKwArgs <- function(...) {
   )
 }
 
+# The purpose of this function is to remove the Python stack trace from an error message
+#  generated when calling Python from R. This makes the command line response more readable
+#  when an error occurs. To support debugging the stack trace truncation can be overridden
+#  by setting the global option 'verbose' to TRUE.
+#
+# @param callable the function to be called
+# @param args the arguments to be passed to the function 'callable'
+# @return the result of calling the given function with the given arguments
 cleanUpStackTrace <- function(callable, args) {
   conn <- textConnection("outputCapture", open = "w", local = TRUE)
   sink(conn)
-  tryCatch({
-    result <- do.call(callable, args)
-    sink()
-    close(conn)
-    cat(paste(outputCapture, collapse = ""))
-    result
-  },
-  error = function(e) {
-    sink()
-    close(conn)
-    errorToReport <- paste(c(outputCapture, e$message), collapse = "\n")
-    if (!getOption("verbose")) {
-      # extract the error message
-      splitArray <- strsplit(errorToReport,
-        "exception-message-boundary",
-        fixed = TRUE
-      )[[1]]
-      if (length(splitArray) >= 2) errorToReport <- splitArray[2]
+  tryCatch(
+    {
+      result <- do.call(callable, args)
+      sink()
+      close(conn)
+      cat(paste(outputCapture, collapse = ""))
+      result
+    },
+    error = function(e) {
+      sink()
+      close(conn)
+      errorToReport <- paste(c(outputCapture, e$message), collapse = "\n")
+      if (!getOption("verbose")) {
+        # extract the error message
+        splitArray <- strsplit(
+          errorToReport,
+          "exception-message-boundary",
+          fixed = TRUE
+        )[[1]]
+        if (length(splitArray) >= 2) errorToReport <- splitArray[2]
+      }
+      stop(.replaceAuthMessage(errorToReport))
     }
-    stop(.replaceAuthMessage(errorToReport))
-  }
   )
 }
 
@@ -742,9 +818,9 @@ cleanUpStackTrace <- function(callable, args) {
 #'   be the name of a Python variable referencing an instance of the class. Otherwise, this must be NULL.
 #'   See example 4.
 #' @param transformReturnObject Optional function to change returned values in R.
-#' @param generateFunctionalInterface Logical. If TRUE, generates functional interface functions 
+#' @param generateFunctionalInterface Logical. If TRUE, generates functional interface functions
 #'   (e.g., synGetProject) in addition to regular class methods. Requires functionPrefix to be set.
-#' @param functionNameMapping Optional list containing mapping configuration for customizing 
+#' @param functionNameMapping Optional list containing mapping configuration for customizing
 #'   functional interface function names. Should contain 'explicit' (direct name mapping).
 #'   Use getSynapseClientModelsMapping() for predefined synapseclient.models mappings.
 #' @details
@@ -871,28 +947,33 @@ cleanUpStackTrace <- function(callable, args) {
 #'   transformReturnObject = myTransform)
 #'
 #' @md
-generateRWrappers <- function(pyPkg,
-                              container,
-                              setGenericCallback,
-                              assignEnumCallback = NULL,
-                              functionFilter = NULL,
-                              classFilter = NULL,
-                              enumFilter = NULL,
-                              functionPrefix = NULL,
-                              pySingletonName = NULL,
-                              transformReturnObject = NULL,
-                              generateFunctionalInterface = FALSE,
-                              functionNameMapping = NULL) {
+generateRWrappers <- function(
+  pyPkg,
+  container,
+  setGenericCallback,
+  assignEnumCallback = NULL,
+  functionFilter = NULL,
+  classFilter = NULL,
+  enumFilter = NULL,
+  functionPrefix = NULL,
+  pySingletonName = NULL,
+  transformReturnObject = NULL,
+  generateFunctionalInterface = FALSE,
+  functionNameMapping = NULL
+) {
   # validate the args
   reticulate::py_run_string("import inspect")
   reticulate::py_run_string(sprintf("import %s", pyPkg))
   isClass <- reticulate::py_eval(sprintf("inspect.isclass(%s)", container))
-  if (isClass && is.null(pySingletonName))
+  if (isClass && is.null(pySingletonName)) {
     stop("`container` is a class, but `pySingtonName` is not specified.")
-  if (!isClass && !is.null(pySingletonName))
+  }
+  if (!isClass && !is.null(pySingletonName)) {
     stop("`container` is not a class, but `pySingtonName` is specified.")
-  if (is.null(assignEnumCallback) && !is.null(enumFilter))
+  }
+  if (is.null(assignEnumCallback) && !is.null(enumFilter)) {
     stop("`enumFilter` is specified, but `assignEnumCallback` is not.")
+  }
 
   functionInfo <- getFunctionInfo(
     pyPkg,
@@ -912,7 +993,7 @@ generateRWrappers <- function(pyPkg,
     functionInfo,
     transformReturnObject
   )
-  
+
   if (generateFunctionalInterface && !is.null(functionPrefix)) {
     autoGenerateClassesWithFunctionalInterface(
       container,
@@ -962,11 +1043,13 @@ initAutoGenerateRdFiles <- function(templateDir) {
 # @param functionInfo list of functions for which to generate doc's
 # @param classInfo list of classes for which to generate doc's
 # @param templateDir (optional) custom templates for the docs
-autoGenerateRdFiles <- function(srcRootDir,
-                                functionInfo,
-                                classInfo,
-                                keepContent,
-                                templateDir = NULL) {
+autoGenerateRdFiles <- function(
+  srcRootDir,
+  functionInfo,
+  classInfo,
+  keepContent,
+  templateDir = NULL
+) {
   if (!file.exists(srcRootDir)) {
     stop(sprintf("%s does not exist.", srcRootDir))
   }
@@ -1004,66 +1087,71 @@ autoGenerateRdFiles <- function(srcRootDir,
     } else {
       returned <- f$returned
     }
-    tryCatch({
-      argDescriptionsFromDoc <- parseArgDescriptionsFromDetails(doc)
-      argNames <- args$args
-      formatArgsResult <- formatArgsForArgumentSection(
-        argNames,
-        argDescriptionsFromDoc
-      )
-      content <- createFunctionRdContent(
-        templateDir = templateDir,
-        alias = name,
-        title = title,
-        description = doc,
-        usage = usage(
-          name,
-          args,
+    tryCatch(
+      {
+        argDescriptionsFromDoc <- parseArgDescriptionsFromDetails(doc)
+        argNames <- args$args
+        formatArgsResult <- formatArgsForArgumentSection(
+          argNames,
           argDescriptionsFromDoc
-        ),
-        argument = formatArgsResult,
-        returned = returned
-      )
-      # make sure all place holders were replaced
-      p <- regexpr("##(title|description|usage|arguments|value|examples)##", content)[1]
-      # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
-      # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
-      writeContent(content, name, targetFolder)
-    },
-    error = function(e) {
-      stop(sprintf("Error generating doc for %s: %s\n", name, e[[1]]))
-    }
+        )
+        content <- createFunctionRdContent(
+          templateDir = templateDir,
+          alias = name,
+          title = title,
+          description = doc,
+          usage = usage(
+            name,
+            args,
+            argDescriptionsFromDoc
+          ),
+          argument = formatArgsResult,
+          returned = returned
+        )
+        # make sure all place holders were replaced
+        p <- regexpr(
+          "##(title|description|usage|arguments|value|examples)##",
+          content
+        )[1]
+        # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
+        # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
+        writeContent(content, name, targetFolder)
+      },
+      error = function(e) {
+        stop(sprintf("Error generating doc for %s: %s\n", name, e[[1]]))
+      }
     )
   }
 
   for (c in classInfo) {
-    tryCatch({
-      content <- createClassRdContent(
-        templateDir = templateDir,
-        alias = paste0(c$name, "-class"),
-        title = c$name,
-        description = c$doc,
-        methods = lapply(
-          X = c$methods,
-          function(x) {
-            argDescriptionsFromDoc <- parseArgDescriptionsFromDetails(x$doc)
-            list(
-              name = x$name,
-              description = x$doc,
-              args = x$args,
-              argDescriptionsFromDoc = argDescriptionsFromDoc
-            )
-          }
+    tryCatch(
+      {
+        content <- createClassRdContent(
+          templateDir = templateDir,
+          alias = paste0(c$name, "-class"),
+          title = c$name,
+          description = c$doc,
+          methods = lapply(
+            X = c$methods,
+            function(x) {
+              argDescriptionsFromDoc <- parseArgDescriptionsFromDetails(x$doc)
+              list(
+                name = x$name,
+                description = x$doc,
+                args = x$args,
+                argDescriptionsFromDoc = argDescriptionsFromDoc
+              )
+            }
+          )
         )
-      )
-      p <- regexpr("##(alias|title|description|methods)##", content)[1]
-      # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
-      # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
-      writeContent(content, paste0(c$name, "-class"), targetFolder)
-    },
-    error = function(e) {
-      stop(sprintf("Error generating doc for %s: %s\n", name, e[[1]]))
-    }
+        p <- regexpr("##(alias|title|description|methods)##", content)[1]
+        # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
+        # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
+        writeContent(content, paste0(c$name, "-class"), targetFolder)
+      },
+      error = function(e) {
+        stop(sprintf("Error generating doc for %s: %s\n", name, e[[1]]))
+      }
     )
   }
 }
@@ -1076,13 +1164,20 @@ usage <- function(name, args, argDescriptionsFromDoc) {
   result <- NULL
   if (length(argNames) > 0) {
     # self can be the first arg of a method or function, typ can be the first arg of a constructor
-    if (argNames[1] != "self" && argNames[1] != "typ") argStart <- 1 else argStart <- 2
+    if (argNames[1] != "self" && argNames[1] != "typ") {
+      argStart <- 1
+    } else {
+      argStart <- 2
+    }
     if (argStart <= length(argNames)) {
       for (i in argStart:length(argNames)) {
         argName <- argNames[[i]]
         defaultIndex <- i + length(defaults) - length(argNames)
         if (defaultIndex > 0) {
-          result <- append(result, sprintf("%s=%s", argName, defaults[defaultIndex]))
+          result <- append(
+            result,
+            sprintf("%s=%s", argName, defaults[defaultIndex])
+          )
         } else {
           result <- append(result, argName)
         }
@@ -1094,12 +1189,15 @@ usage <- function(name, args, argDescriptionsFromDoc) {
   # are there any remaining arguments, not included in the argument list?
   # if so, they are kwargs / named parameters
   if (length(names(argDescriptionsFromDoc)) > 0) {
-    result <- append(result, lapply(
-      names(argDescriptionsFromDoc),
-      function(x) {
-        sprintf("%s=NULL", x)
-      }
-    ))
+    result <- append(
+      result,
+      lapply(
+        names(argDescriptionsFromDoc),
+        function(x) {
+          sprintf("%s=NULL", x)
+        }
+      )
+    )
   }
   sprintf("%s(%s)", name, paste(result, collapse = ", "))
 }
@@ -1111,27 +1209,43 @@ usage <- function(name, args, argDescriptionsFromDoc) {
 formatArgsForArgumentSection <- function(argNames, argDescriptionsFromDoc) {
   result <- NULL
   if (length(argNames) > 0) {
-    if (argNames[1] != "self" && argNames[1] != "typ") argStart <- 1 else argStart <- 2
+    if (argNames[1] != "self" && argNames[1] != "typ") {
+      argStart <- 1
+    } else {
+      argStart <- 2
+    }
     if (argStart <= length(argNames)) {
       for (i in argStart:length(argNames)) {
         argName <- argNames[[i]]
         argDescription <- argDescriptionsFromDoc[[argName]]
         # remove it from the list of arguments mentioned in the docstring
         argDescriptionsFromDoc[[argName]] <- NULL
-        if (is.null(argDescription)) argDescription <- ""
-        result <- append(result, sprintf("\\item{%s}{%s}", argName, argDescription))
+        if (is.null(argDescription)) {
+          argDescription <- ""
+        }
+        result <- append(
+          result,
+          sprintf("\\item{%s}{%s}", argName, argDescription)
+        )
       }
     }
   }
   # are there any remaining arguments, not included in the argument list?
   # if so, they are kwargs / named parameters
   if (length(argDescriptionsFromDoc) > 0) {
-    result <- append(result, lapply(
-      names(argDescriptionsFromDoc),
-      function(x) {
-        sprintf("\\item{%s}{optional named parameter: %s}", x, argDescriptionsFromDoc[[x]])
-      }
-    ))
+    result <- append(
+      result,
+      lapply(
+        names(argDescriptionsFromDoc),
+        function(x) {
+          sprintf(
+            "\\item{%s}{optional named parameter: %s}",
+            x,
+            argDescriptionsFromDoc[[x]]
+          )
+        }
+      )
+    )
   }
   paste(result, collapse = "\n")
 }
@@ -1193,13 +1307,18 @@ parseArgDescriptionsFromDetails <- function(raw) {
   )
   result$unusedPrefix <- NULL
   if (length(names(result)) != length(unique(names(result)))) {
-    message(sprintf("Warning:  encountered repeated function arguments definitions in docstring: %s", raw))
+    message(sprintf(
+      "Warning:  encountered repeated function arguments definitions in docstring: %s",
+      raw
+    ))
   }
   result
 }
 
 pyVerbiageToLatex <- function(raw) {
-  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) return("")
+  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) {
+    return("")
+  }
   # this replaces ':param <param name>:' with '\nparam name:'
   # same for parameter, type, var
   result <- raw
@@ -1208,13 +1327,19 @@ pyVerbiageToLatex <- function(raw) {
   result <- gsub(":py:class:`(\\S+\\.)*(\\S+)`", "\\2", result)
 
   convertToUpper <- "##convertToUpper##" # marks character to convert
-  result <- gsub(":py:mod:`(\\S+\\.)*(\\S+)`", paste0(convertToUpper, "\\2"), result)
+  result <- gsub(
+    ":py:mod:`(\\S+\\.)*(\\S+)`",
+    paste0(convertToUpper, "\\2"),
+    result
+  )
   # anything else we simply leave in place for manual curation:
   result <- gsub(":py:(func|meth):`([^`]*)`", "\\2", result)
 
   while (TRUE) {
     ctuIndex <- regexpr(convertToUpper, result)[[1]]
-    if (ctuIndex < 0) break
+    if (ctuIndex < 0) {
+      break
+    }
     lcChar <- nchar(convertToUpper) + ctuIndex
     # Check if lcChar is beyond the string length
     if (lcChar > nchar(result)) {
@@ -1233,39 +1358,66 @@ pyVerbiageToLatex <- function(raw) {
 }
 
 getDescription <- function(raw) {
-  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) return("")
+  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) {
+    return("")
+  }
   preprocessed <- gsub("\r\n", "\n", raw, fixed = TRUE)
   # find everything up to the first syphinx token following the description
-  terminatorIndex <- regexpr("\n*:(parameter|param|type|var)|\n*?:returns?:|\n{1,}[Ee]xample:", preprocessed)[1]
-  if (terminatorIndex < 1) return(preprocessed)
+  terminatorIndex <- regexpr(
+    "\n*:(parameter|param|type|var)|\n*?:returns?:|\n{1,}[Ee]xample:",
+    preprocessed
+  )[1]
+  if (terminatorIndex < 1) {
+    return(preprocessed)
+  }
   substr(preprocessed, 1, terminatorIndex - 1)
 }
 
 getReturned <- function(raw) {
-  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) return("")
+  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) {
+    return("")
+  }
   preprocessed <- gsub("\r\n", "\n", raw, fixed = TRUE)
-  if (!grepl(":returns?:", preprocessed)) return("")
+  if (!grepl(":returns?:", preprocessed)) {
+    return("")
+  }
   # get whatever follows :return: or :returns:
   result <- gsub(".*:returns?:(.*)", "\\1", preprocessed)
   # check for any trailing content
   doubleNewLineIndex <- regexpr("\n\n", result)[1]
-  if (doubleNewLineIndex <= 1) return(result)
+  if (doubleNewLineIndex <= 1) {
+    return(result)
+  }
   substr(result, 1, doubleNewLineIndex - 1)
 }
 
 getExample <- function(raw) {
-  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) return("")
+  if (missing(raw) || is.null(raw) || length(raw) == 0 || nchar(raw) == 0) {
+    return("")
+  }
   preprocessed <- gsub("\r\n", "\n", raw, fixed = TRUE)
   pattern <- ".*[Ee]xample::?\n\n(.*)"
-  if (!grepl(pattern, preprocessed)) return("")
+  if (!grepl(pattern, preprocessed)) {
+    return("")
+  }
   result <- gsub(pattern, "\\1", preprocessed)
   # check for any trailing content
   doubleNewLineIndex <- regexpr("\n\n", result)[1]
-  if (doubleNewLineIndex <= 1) return(result)
+  if (doubleNewLineIndex <= 1) {
+    return(result)
+  }
   substr(result, 1, doubleNewLineIndex - 1)
 }
 
-createFunctionRdContent <- function(templateDir, alias, title, description, usage, argument, returned) {
+createFunctionRdContent <- function(
+  templateDir,
+  alias,
+  title,
+  description,
+  usage,
+  argument,
+  returned
+) {
   templateFile <- sprintf("%s/rdFunctionTemplate.Rd", templateDir)
   connection <- file(templateFile, open = "r")
   template <- paste(readLines(connection), collapse = "\n")
@@ -1273,11 +1425,18 @@ createFunctionRdContent <- function(templateDir, alias, title, description, usag
 
   content <- template
   content <- gsub("##alias##", alias, content, fixed = TRUE)
-  if (!missing(title) && !is.null(title)) content <- gsub("##title##", title, content, fixed = TRUE)
+  if (!missing(title) && !is.null(title)) {
+    content <- gsub("##title##", title, content, fixed = TRUE)
+  }
   examples <- NULL
   if (!missing(description) && !is.null(description)) {
     processedDescription <- pyVerbiageToLatex(getDescription(description))
-    content <- gsub("##description##", processedDescription, content, fixed = TRUE)
+    content <- gsub(
+      "##description##",
+      processedDescription,
+      content,
+      fixed = TRUE
+    )
     examples <- pyVerbiageToLatex(getExample(description))
   } else {
     content <- gsub("##description##", "", content, fixed = TRUE)
@@ -1288,21 +1447,41 @@ createFunctionRdContent <- function(templateDir, alias, title, description, usag
   } else {
     content <- gsub("##value##", "", content, fixed = TRUE)
   }
-  if (!missing(usage) && !is.null(usage)) content <- gsub("##usage##", usage, content, fixed = TRUE)
-  if (!missing(argument) && !is.null(argument)) content <- gsub("##arguments##", argument, content, fixed = TRUE)
+  if (!missing(usage) && !is.null(usage)) {
+    content <- gsub("##usage##", usage, content, fixed = TRUE)
+  }
+  if (!missing(argument) && !is.null(argument)) {
+    content <- gsub("##arguments##", argument, content, fixed = TRUE)
+  }
   if (!is.null(examples) && length(examples) > 0 && nchar(examples) > 0) {
     content <- paste(content, "\n\\examples{\n##examples##\n}", collapse = "\n")
     # we comment out the examples which come from the Python client and need to be curated
-    content <- gsub("##examples##", paste0("%\\dontrun{\n%", gsub("\n", "\n%", examples), "\n%}"), content, fixed = TRUE)
+    content <- gsub(
+      "##examples##",
+      paste0("%\\dontrun{\n%", gsub("\n", "\n%", examples), "\n%}"),
+      content,
+      fixed = TRUE
+    )
   }
   content
 }
 
 createMethodContent <- function(f) {
-  paste0("\\item \\code{", usage(f$name, f$args, f$argDescriptionsFromDoc), "}: ", f$description)
+  paste0(
+    "\\item \\code{",
+    usage(f$name, f$args, f$argDescriptionsFromDoc),
+    "}: ",
+    f$description
+  )
 }
 
-createClassRdContent <- function(templateDir, alias, title, description, methods) {
+createClassRdContent <- function(
+  templateDir,
+  alias,
+  title,
+  description,
+  methods
+) {
   templateFile <- sprintf("%s/rdClassTemplate.Rd", templateDir)
   connection <- file(templateFile, open = "r")
   template <- paste(readLines(connection), collapse = "\n")
@@ -1310,10 +1489,17 @@ createClassRdContent <- function(templateDir, alias, title, description, methods
 
   content <- template
   content <- gsub("##alias##", alias, content, fixed = TRUE)
-  if (!missing(title) && !is.null(title)) content <- gsub("##title##", title, content, fixed = TRUE)
+  if (!missing(title) && !is.null(title)) {
+    content <- gsub("##title##", title, content, fixed = TRUE)
+  }
   if (!missing(description) && !is.null(description)) {
     processedDescription <- pyVerbiageToLatex(getDescription(description))
-    content <- gsub("##description##", processedDescription, content, fixed = TRUE)
+    content <- gsub(
+      "##description##",
+      processedDescription,
+      content,
+      fixed = TRUE
+    )
   }
   methodContent <- NULL
   for (method in methods) {
@@ -1322,14 +1508,21 @@ createClassRdContent <- function(templateDir, alias, title, description, methods
       method$description <- sprintf("Constructor for \\code{\\link{%s}}", title)
     } else {
       if (!is.null(methodDescription)) {
-        methodDescription <- pyVerbiageToLatex(getDescription(methodDescription))
+        methodDescription <- pyVerbiageToLatex(getDescription(
+          methodDescription
+        ))
         methodDescription <- insertLatexNewLines(methodDescription)
         method$description <- methodDescription
       }
     }
     methodContent <- c(methodContent, createMethodContent(method))
   }
-  content <- gsub("##methods##", paste(methodContent, collapse = "\n"), content, fixed = TRUE)
+  content <- gsub(
+    "##methods##",
+    paste(methodContent, collapse = "\n"),
+    content,
+    fixed = TRUE
+  )
   content
 }
 
@@ -1355,9 +1548,9 @@ writeContent <- function(content, name, targetFolder) {
 #' @param keepContent Optional whether the existing files at the target directory should be kept.
 #' @param templateDir Optional path to a template directory. Set `templateDir` to NULL to use the default
 #'   templates in the `/templates/` folder.
-#' @param generateFunctionalInterface Logical. If TRUE, generates documentation for functional interface 
+#' @param generateFunctionalInterface Logical. If TRUE, generates documentation for functional interface
 #'   functions (e.g., synGetProject) in addition to regular class methods. Requires functionPrefix to be set.
-#' @param functionNameMapping Optional list containing mapping configuration for customizing 
+#' @param functionNameMapping Optional list containing mapping configuration for customizing
 #'   functional interface function names. Should contain 'explicit' (direct name mapping).
 #'   Use getSynapseClientModelsMapping() for predefined synapseclient.models mappings.
 #' @details
@@ -1445,30 +1638,46 @@ writeContent <- function(content, name, targetFolder) {
 #'   functionPrefix = "syn",
 #'   generateFunctionalInterface = TRUE)
 #' @md
-generateRdFiles <- function(srcRootDir,
-                            pyPkg,
-                            container,
-                            functionFilter = NULL,
-                            classFilter = NULL,
-                            functionPrefix = NULL,
-                            keepContent = FALSE,
-                            templateDir = NULL,
-                            generateFunctionalInterface = FALSE,
-                            functionNameMapping = NULL) {
-
-  functionInfo <- getFunctionInfo(pyPkg, container, functionFilter, functionPrefix)
+generateRdFiles <- function(
+  srcRootDir,
+  pyPkg,
+  container,
+  functionFilter = NULL,
+  classFilter = NULL,
+  functionPrefix = NULL,
+  keepContent = FALSE,
+  templateDir = NULL,
+  generateFunctionalInterface = FALSE,
+  functionNameMapping = NULL
+) {
+  functionInfo <- getFunctionInfo(
+    pyPkg,
+    container,
+    functionFilter,
+    functionPrefix
+  )
   classInfo <- getClassInfo(pyPkg, container, classFilter)
-  
+
   # Generate functional interface function info if requested
   functionalInterfaceInfo <- list()
   if (generateFunctionalInterface && !is.null(functionPrefix)) {
-    functionalInterfaceInfo <- generateFunctionalInterfaceInfo(classInfo, functionPrefix, functionNameMapping)
+    functionalInterfaceInfo <- generateFunctionalInterfaceInfo(
+      classInfo,
+      functionPrefix,
+      functionNameMapping
+    )
   }
-  
+
   # Combine all function info (regular functions + functional interface functions)
   allFunctionInfo <- c(functionInfo, functionalInterfaceInfo)
 
-  autoGenerateRdFiles(srcRootDir, allFunctionInfo, classInfo, keepContent, file.path(srcRootDir, "inst", "templates"))
+  autoGenerateRdFiles(
+    srcRootDir,
+    allFunctionInfo,
+    classInfo,
+    keepContent,
+    file.path(srcRootDir, "inst", "templates")
+  )
 }
 
 # Helper function to generate functional interface function info for documentation
@@ -1476,9 +1685,13 @@ generateRdFiles <- function(srcRootDir,
 # @param classInfo the classes to extract functional interface info from
 # @param functionPrefix the prefix to add to functional method names (e.g., "syn")
 # @param functionNameMapping the mapping configuration for customizing function names
-generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", functionNameMapping = NULL) {
+generateFunctionalInterfaceInfo <- function(
+  classInfo,
+  functionPrefix = "syn",
+  functionNameMapping = NULL
+) {
   functionalInfo <- list()
-  
+
   for (c in classInfo) {
     # Generate info for class methods (excluding constructor)
     if (!is.null(c$methods)) {
@@ -1486,7 +1699,10 @@ generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", f
         # Skip the constructor method (it has the same name as the class)
         if (method$name != c$name) {
           # Generic name — no class suffix; dispatch table routes per class
-          defaultGenericName <- paste0(functionPrefix, snakeToCamel(method$name))
+          defaultGenericName <- paste0(
+            functionPrefix,
+            snakeToCamel(method$name)
+          )
           functionalRFunctionName <- applyFunctionNameMapping(
             defaultGenericName,
             functionNameMapping
@@ -1500,21 +1716,32 @@ generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", f
 
           functionalFunctionInfo <- list(
             pyName = method$name,
-            rName = functionalRFunctionName,   # public generic, e.g. "synStore"
-            targetClass = c$name,              # e.g. "File" — which class this entry covers
+            rName = functionalRFunctionName, # public generic, e.g. "synStore"
+            targetClass = c$name, # e.g. "File" — which class this entry covers
             functionContainerName = paste0(c$name, ".", method$name),
             args = modifiedArgs,
             doc = method$doc,
-            title = paste("Functional interface for", c$name, method$name, "method"),
-            returned = paste("Result of calling", method$name, "method on", c$name, "instance")
+            title = paste(
+              "Functional interface for",
+              c$name,
+              method$name,
+              "method"
+            ),
+            returned = paste(
+              "Result of calling",
+              method$name,
+              "method on",
+              c$name,
+              "instance"
+            )
           )
-          
+
           functionalInfo <- append(functionalInfo, list(functionalFunctionInfo))
         }
       }
     }
   }
-  
+
   return(functionalInfo)
 }
 
@@ -1526,7 +1753,7 @@ applyFunctionNameMapping <- function(defaultName, mappingConfig = NULL) {
   if (is.null(mappingConfig)) {
     return(defaultName)
   }
-  
+
   # Try explicit mapping table
   if (!is.null(mappingConfig$explicit)) {
     mapped <- mappingConfig$explicit[[defaultName]]
@@ -1534,7 +1761,7 @@ applyFunctionNameMapping <- function(defaultName, mappingConfig = NULL) {
       return(mapped)
     }
   }
-  
+
   # Return default if no mapping found
   return(defaultName)
 }

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -103,6 +103,161 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
   setGenericCallback(name, rFn)
 }
 
+# Define an R wrapper for a method of a Python class
+#
+# @param module the python module
+# @param setGenericCallback the callback to setGeneric defined in the target R package
+# @param className the name of the Python class
+# @param methodName the name of the method for R (could be camelCase)
+# @param pyParams the function info args as from getFunctionInfo
+# @param pythonMethodName the original Python method name (snake_case), if NULL uses methodName
+defineClassMethod <- function(module, setGenericCallback, className, methodName, pyParams, pythonMethodName = NULL) {
+  force(className)
+  force(methodName)
+  force(module)
+  force(pyParams)
+  
+  # If pythonMethodName is not provided, use methodName
+  if (is.null(pythonMethodName)) {
+    pythonMethodName <- methodName
+  }
+  force(pythonMethodName)
+
+  # Create a unique R function name for the class method
+  rFunctionName <- sprintf("%s_%s", className, methodName)
+  rWrapperName <- sprintf(".%s_%s", className, methodName)
+  
+  gateway <- reticulate::import("gateway")
+  assign(rWrapperName, function(instance, ...) {
+    if (missing(instance) || is.null(instance)) {
+      stop(sprintf("The first argument must be an instance of %s", className))
+    }
+    argsAndKwArgs <- determineArgsAndKwArgs(...)
+    returnedObject <- cleanUpStackTrace(
+      gateway$invoke,
+      list(
+        method = list(instance, pythonMethodName),
+        args = argsAndKwArgs$args,
+        kwargs = argsAndKwArgs$kwargs
+      )
+    )
+    if (grepl("GeneratorWrapper", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "GeneratorWrapper"
+    }
+    if (grepl("CsvFileTable", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "CsvFileTable"
+    }
+    returnedObject
+  })
+
+  rFn <- function(instance, ...) {
+    # formals will be assigned below, re-create the dots
+    # so we can pass them through to the py call
+    call <- sys.call()
+    call[[1]] <- as.name('list')
+    dots <- eval.parent(call)
+    do.call(rWrapperName, args = dots)
+  }
+
+  # Create formal arguments for the method, including the instance parameter
+  newArgs <- .createFormalArgs(pyParams)
+  if (length(newArgs) > 0) {
+    # Remove 'self' from arguments if it exists and add 'instance' as first parameter
+    if (!is.null(newArgs) && "self" %in% names(newArgs)) {
+      newArgs <- newArgs[names(newArgs) != "self"]
+    }
+    newArgs <- append(list(instance = quote(expr =)), newArgs, after = 0)
+  } else {
+    newArgs <- list(instance = quote(expr =))
+  }
+  
+  formals(rFn) <- newArgs
+  setGenericCallback(rFunctionName, rFn)
+}
+
+# Define a functional R wrapper for a method of a Python class
+# This creates functions like synGetProject() that can be used with R-style piping
+#
+# @param module the python module
+# @param setGenericCallback the callback to setGeneric defined in the target R package
+# @param className the name of the Python class
+# @param methodName the name of the method for R (could be camelCase)
+# @param pyParams the function info args as from getFunctionInfo
+# @param pythonMethodName the original Python method name (snake_case), if NULL uses methodName
+# @param functionPrefix the prefix to add to the function name (e.g., "syn")
+# @param functionNameMapping the mapping configuration for customizing function names
+defineFunctionalClassMethod <- function(module, setGenericCallback, className, methodName, pyParams, pythonMethodName = NULL, functionPrefix = "syn", functionNameMapping = NULL) {
+  force(className)
+  force(methodName)
+  force(module)
+  force(pyParams)
+  force(functionPrefix)
+  
+  # If pythonMethodName is not provided, use methodName
+  if (is.null(pythonMethodName)) {
+    pythonMethodName <- methodName
+  }
+  force(pythonMethodName)
+
+  # Create a functional R function name like synGetProject
+  defaultFunctionalName <- paste0(functionPrefix, snakeToCamel(methodName), className)
+  
+  # Apply custom mapping if provided
+  functionalRFunctionName <- applyFunctionNameMapping(
+    defaultFunctionalName, 
+    functionNameMapping
+  )
+  
+  rWrapperName <- sprintf(".%s", functionalRFunctionName)
+  
+  gateway <- reticulate::import("gateway")
+  assign(rWrapperName, function(instance, ...) {
+    if (missing(instance) || is.null(instance)) {
+      stop(sprintf("The first argument must be an instance of %s", className))
+    }
+    argsAndKwArgs <- determineArgsAndKwArgs(...)
+    returnedObject <- cleanUpStackTrace(
+      gateway$invoke,
+      list(
+        method = list(instance, pythonMethodName),
+        args = argsAndKwArgs$args,
+        kwargs = argsAndKwArgs$kwargs
+      )
+    )
+    if (grepl("GeneratorWrapper", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "GeneratorWrapper"
+    }
+    if (grepl("CsvFileTable", class(returnedObject)[1])) {
+      class(returnedObject)[1] <- "CsvFileTable"
+    }
+    returnedObject
+  })
+
+  rFn <- function(instance, ...) {
+    # formals will be assigned below, re-create the dots
+    # so we can pass them through to the py call
+    call <- sys.call()
+    call[[1]] <- as.name('list')
+    dots <- eval.parent(call)
+    do.call(rWrapperName, args = dots)
+  }
+
+  # Create formal arguments for the method, including the instance parameter
+  newArgs <- .createFormalArgs(pyParams)
+  if (length(newArgs) > 0) {
+    # Remove 'self' from arguments if it exists and add 'instance' as first parameter
+    if (!is.null(newArgs) && "self" %in% names(newArgs)) {
+      newArgs <- newArgs[names(newArgs) != "self"]
+    }
+    newArgs <- append(list(instance = quote(expr =)), newArgs, after = 0)
+  } else {
+    newArgs <- list(instance = quote(expr =))
+  }
+  
+  formals(rFn) <- newArgs
+  setGenericCallback(functionalRFunctionName, rFn)
+}
+
 # Helper function to generate R wrappers for classes in a python module
 #
 # @param module the python module
@@ -110,7 +265,43 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
 # @param classInfo the classes to generate R wrappers for
 autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
   for (c in classInfo) {
-    defineConstructor(module, setGenericCallback, c$name, c$args)
+    defineConstructor(module, setGenericCallback, c$name, c$constructorArgs)
+    
+    # Generate wrappers for class methods (excluding constructor)
+    if (!is.null(c$methods)) {
+      for (method in c$methods) {
+        # Skip the constructor method (it has the same name as the class)
+        if (method$name != c$name) {
+          defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
+        }
+      }
+    }
+  }
+}
+
+# Helper function to generate both regular class methods and functional interfaces
+#
+# @param module the python module
+# @param setGenericCallback the callback to setGeneric defined in the target R package
+# @param classInfo the classes to generate R wrappers for
+# @param functionPrefix the prefix to add to functional method names (e.g., "syn")
+# @param functionNameMapping the mapping configuration for customizing function names
+autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallback, classInfo, functionPrefix = "syn", functionNameMapping = NULL, verbose = FALSE) {
+  for (c in classInfo) {
+    if (nzchar(Sys.getenv("R_INSTALL_PKG"))) cat(sprintf("Creating class wrapper for: %s\n", c$name))
+    defineConstructor(module, setGenericCallback, c$name, c$constructorArgs)
+    
+    # Generate wrappers for class methods (excluding constructor)
+    if (!is.null(c$methods)) {
+      for (method in c$methods) {
+        # Skip the constructor method (it has the same name as the class)
+        if (method$name != c$name) {      
+          # Create both regular class method and functional interface
+          defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
+          defineFunctionalClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name, functionPrefix, functionNameMapping)
+        }
+      }
+    }
   }
 }
 
@@ -379,6 +570,21 @@ determineArgsAndKwArgs <- function(...) {
 # @param callable the function to be called
 # @param args the arguments to be passed to the function 'callable'
 # @return the result of calling the given function with the given arguments
+.rAuthMessage <- paste0(
+  "You have not provided valid credentials for authentication with Synapse. ",
+  "Please provide an authentication token and use `synLogin()` before your next attempt. ",
+  "See https://r-docs.synapse.org/articles/manageSynapseCredentials.html for more information."
+)
+
+.replaceAuthMessage <- function(text) {
+  gsub(
+    "You have not provided valid credentials.*?for more information\\.",
+    .rAuthMessage,
+    text,
+    perl = TRUE
+  )
+}
+
 cleanUpStackTrace <- function(callable, args) {
   conn <- textConnection("outputCapture", open = "w", local = TRUE)
   sink(conn)
@@ -386,7 +592,7 @@ cleanUpStackTrace <- function(callable, args) {
     result <- do.call(callable, args)
     sink()
     close(conn)
-    cat(paste(outputCapture, collapse = ""))
+    cat(.replaceAuthMessage(paste(outputCapture, collapse = "")))
     result
   },
   error = function(e) {
@@ -401,7 +607,7 @@ cleanUpStackTrace <- function(callable, args) {
       )[[1]]
       if (length(splitArray) >= 2) errorToReport <- splitArray[2]
     }
-    stop(errorToReport)
+    stop(.replaceAuthMessage(errorToReport))
   }
   )
 }
@@ -422,10 +628,15 @@ cleanUpStackTrace <- function(callable, args) {
 #'   be the name of a Python variable referencing an instance of the class. Otherwise, this must be NULL.
 #'   See example 4.
 #' @param transformReturnObject Optional function to change returned values in R.
+#' @param generateFunctionalInterface Logical. If TRUE, generates functional interface functions 
+#'   (e.g., synGetProject) in addition to regular class methods. Requires functionPrefix to be set.
+#' @param functionNameMapping Optional list containing mapping configuration for customizing 
+#'   functional interface function names. Should contain 'explicit' (direct name mapping).
+#'   Use getSynapseClientModelsMapping() for predefined synapseclient.models mappings.
 #' @details
 #' * `container` can take the same value as `pyPkg`, can be a module or class within the Python package.
 #'
-#' * `setGeneric` function must be defined in the same environment that `generateRWrappers`
+#' * `setGenericCallback` function must be defined in the same environment that `generateRWrappers`
 #'   is called. See example 1.
 #'
 #' * `functionFilter` and `classFilter` are optional functions defined by the caller.
@@ -555,7 +766,9 @@ generateRWrappers <- function(pyPkg,
                               enumFilter = NULL,
                               functionPrefix = NULL,
                               pySingletonName = NULL,
-                              transformReturnObject = NULL) {
+                              transformReturnObject = NULL,
+                              generateFunctionalInterface = FALSE,
+                              functionNameMapping = NULL) {
   # validate the args
   reticulate::py_run_string("import inspect")
   reticulate::py_run_string(sprintf("import %s", pyPkg))
@@ -585,11 +798,22 @@ generateRWrappers <- function(pyPkg,
     functionInfo,
     transformReturnObject
   )
-  autoGenerateClasses(
-    container,
-    setGenericCallback,
-    classInfo
-  )
+  
+  if (generateFunctionalInterface && !is.null(functionPrefix)) {
+    autoGenerateClassesWithFunctionalInterface(
+      container,
+      setGenericCallback,
+      classInfo,
+      functionPrefix,
+      functionNameMapping
+    )
+  } else {
+    autoGenerateClasses(
+      container,
+      setGenericCallback,
+      classInfo
+    )
+  }
   if (!is.null(assignEnumCallback)) {
     enumInfo <- getEnumInfo(
       pyPkg,
@@ -688,7 +912,8 @@ autoGenerateRdFiles <- function(srcRootDir,
       )
       # make sure all place holders were replaced
       p <- regexpr("##(title|description|usage|arguments|value|examples)##", content)[1]
-      if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
+      # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
+      # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
       writeContent(content, name, targetFolder)
     },
     error = function(e) {
@@ -718,7 +943,8 @@ autoGenerateRdFiles <- function(srcRootDir,
         )
       )
       p <- regexpr("##(alias|title|description|methods)##", content)[1]
-      if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
+      # TODO: This is an issue in some of the legacy objects where this is failing. More work is needed to determine why this fails
+      # if (p > 0) stop(sprintf("Failed to replace all placeholders in %s.Rd", name))
       writeContent(content, paste0(c$name, "-class"), targetFolder)
     },
     error = function(e) {
@@ -877,14 +1103,18 @@ pyVerbiageToLatex <- function(raw) {
     ctuIndex <- regexpr(convertToUpper, result)[[1]]
     if (ctuIndex < 0) break
     lcChar <- nchar(convertToUpper) + ctuIndex
-    result <- paste0(
-      substring(result, 1, ctuIndex - 1),
-      toupper(substring(result, lcChar, lcChar)),
-      substring(result, lcChar + 1)
-    )
+    # Check if lcChar is beyond the string length
+    if (lcChar > nchar(result)) {
+      # If marker is at the end, just remove it
+      result <- substring(result, 1, ctuIndex - 1)
+    } else {
+      result <- paste0(
+        substring(result, 1, ctuIndex - 1),
+        toupper(substring(result, lcChar, lcChar)),
+        substring(result, lcChar + 1)
+      )
+    }
   }
-
-  result <- gsub(dictDocString, "\nConstructor accepts named arguments.\n", result, fixed = TRUE)
 
   result <- convertSphinxToLatex(result)
 }
@@ -1012,6 +1242,11 @@ writeContent <- function(content, name, targetFolder) {
 #' @param keepContent Optional whether the existing files at the target directory should be kept.
 #' @param templateDir Optional path to a template directory. Set `templateDir` to NULL to use the default
 #'   templates in the `/templates/` folder.
+#' @param generateFunctionalInterface Logical. If TRUE, generates documentation for functional interface 
+#'   functions (e.g., synGetProject) in addition to regular class methods. Requires functionPrefix to be set.
+#' @param functionNameMapping Optional list containing mapping configuration for customizing 
+#'   functional interface function names. Should contain 'explicit' (direct name mapping).
+#'   Use getSynapseClientModelsMapping() for predefined synapseclient.models mappings.
 #' @details
 #' * `container` can take the same value as `pyPkg`, can be a module or a class within the Python package.
 #'
@@ -1088,6 +1323,14 @@ writeContent <- function(content, name, targetFolder) {
 #'   pyPkg = "pyPackageName",
 #'   container = "pyPackageName.aModuleInPyPackageName",
 #'   classFilter = myclassFilter)
+#'
+#' # 4. Generate docs including functional interface functions (e.g., synDatasetGet, synProjectStore)
+#' generateRdFiles(
+#'   srcRootDir = "path/to/R/pkg",
+#'   pyPkg = "pyPackageName",
+#'   container = "pyPackageName.aModuleInPyPackageName",
+#'   functionPrefix = "syn",
+#'   generateFunctionalInterface = TRUE)
 #' @md
 generateRdFiles <- function(srcRootDir,
                             pyPkg,
@@ -1096,10 +1339,99 @@ generateRdFiles <- function(srcRootDir,
                             classFilter = NULL,
                             functionPrefix = NULL,
                             keepContent = FALSE,
-                            templateDir = NULL) {
+                            templateDir = NULL,
+                            generateFunctionalInterface = FALSE,
+                            functionNameMapping = NULL) {
 
   functionInfo <- getFunctionInfo(pyPkg, container, functionFilter, functionPrefix)
   classInfo <- getClassInfo(pyPkg, container, classFilter)
+  
+  # Generate functional interface function info if requested
+  functionalInterfaceInfo <- list()
+  if (generateFunctionalInterface && !is.null(functionPrefix)) {
+    functionalInterfaceInfo <- generateFunctionalInterfaceInfo(classInfo, functionPrefix, functionNameMapping)
+  }
+  
+  # Combine all function info (regular functions + functional interface functions)
+  allFunctionInfo <- c(functionInfo, functionalInterfaceInfo)
 
-  autoGenerateRdFiles(srcRootDir, functionInfo, classInfo, keepContent, file.path(srcRootDir, "inst", "templates"))
+  autoGenerateRdFiles(srcRootDir, allFunctionInfo, classInfo, keepContent, file.path(srcRootDir, "inst", "templates"))
+}
+
+# Helper function to generate functional interface function info for documentation
+#
+# @param classInfo the classes to extract functional interface info from
+# @param functionPrefix the prefix to add to functional method names (e.g., "syn")
+# @param functionNameMapping the mapping configuration for customizing function names
+generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", functionNameMapping = NULL) {
+  functionalInfo <- list()
+  
+  for (c in classInfo) {
+    # Generate info for class methods (excluding constructor)
+    if (!is.null(c$methods)) {
+      for (method in c$methods) {
+        # Skip the constructor method (it has the same name as the class)
+        if (method$name != c$name) {
+          # Create functional R function name like synGetProject
+          defaultFunctionalName <- paste0(functionPrefix, snakeToCamel(method$name), c$name)
+          
+          # Apply custom mapping if provided
+          functionalRFunctionName <- applyFunctionNameMapping(
+            defaultFunctionalName,
+            functionNameMapping
+          )
+          
+          # Create modified args where 'self' is replaced with 'instance'
+          modifiedArgs <- method$args
+          if (!is.null(modifiedArgs) && "self" %in% modifiedArgs$args) {
+            # Replace 'self' with 'instance' in the args list
+            selfIndex <- which(modifiedArgs$args == "self")
+            modifiedArgs$args[selfIndex] <- "instance"
+          } else if (!is.null(modifiedArgs$args)) {
+            # Add 'instance' as first parameter if 'self' wasn't found
+            modifiedArgs$args <- c("instance", modifiedArgs$args)
+          } else {
+            # Create args structure with just 'instance'
+            modifiedArgs <- list(args = "instance", varargs = NULL, keywords = NULL, defaults = NULL)
+          }
+          
+          # Create functional interface function info
+          functionalFunctionInfo <- list(
+            pyName = method$name,
+            rName = functionalRFunctionName,
+            functionContainerName = paste0(c$name, ".", method$name),
+            args = modifiedArgs,
+            doc = method$doc,
+            title = paste("Functional interface for", c$name, method$name, "method"),
+            returned = paste("Result of calling", method$name, "method on", c$name, "instance")
+          )
+          
+          functionalInfo <- append(functionalInfo, list(functionalFunctionInfo))
+        }
+      }
+    }
+  }
+  
+  return(functionalInfo)
+}
+
+# Helper function to apply function name mapping if configured
+#
+# @param defaultName the default generated function name
+# @param mappingConfig the mapping configuration list
+applyFunctionNameMapping <- function(defaultName, mappingConfig = NULL) {
+  if (is.null(mappingConfig)) {
+    return(defaultName)
+  }
+  
+  # Try explicit mapping table
+  if (!is.null(mappingConfig$explicit)) {
+    mapped <- mappingConfig$explicit[[defaultName]]
+    if (!is.null(mapped)) {
+      return(mapped)
+    }
+  }
+  
+  # Return default if no mapping found
+  return(defaultName)
 }

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -4,6 +4,35 @@
 #
 # ------------------------------------------------------------------------------
 
+# Dispatch table for functional interface inner workers.
+# Populated by defineFunctionalClassMethod; looked up at call time by the generic.
+# This is a global variable that is used to store the inner workers for the functional interface.
+# It is used to dispatch to the correct inner worker function based on the class of the object.
+# Key: "<genericName>_<className>", Value: inner worker function to call the Python method on the instance.
+# The key is the generic name and the class name.
+# The inner worker function is a function that takes an instance and ... as arguments and calls the Python method on the instance.
+# Example:
+# .functionalMethodDispatch
+#  ├── synGetAcl_File      → function(instance, ...) # calls the Python method on the instance
+#  ├── synGetAcl_Project   → function(instance, ...) # calls the Python method on the instance
+#  └── ...
+#
+.functionalMethodDispatch <- new.env(parent = emptyenv())
+
+# Lazily cached gateway module — imported once, reused everywhere.
+.gateway <- NULL
+.getGateway <- function() {
+  if (is.null(.gateway)) .gateway <<- reticulate::import("gateway")
+  .gateway
+}
+
+# Import sys, pyPkgInfo, and the target Python package once per call site.
+.initPyPkgInfo <- function(pyPkg) {
+  reticulate::py_run_string("import sys")
+  reticulate::py_run_string("import pyPkgInfo")
+  reticulate::py_run_string(sprintf("import %s", pyPkg))
+}
+
 # Helper function to generate R wrappers for Enum classes in a python module
 #
 # @param assignEnumCallback the callback to define the enum in the target R package
@@ -72,7 +101,7 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
   force(pyParams)
 
   rWrapperName <- sprintf(".%s", name)
-  gateway <- reticulate::import("gateway")
+  gateway <- .getGateway()
   assign(rWrapperName, function(...) {
     pyModule <- reticulate::py_eval(module)
     argsAndKwArgs <- determineArgsAndKwArgs(...)
@@ -84,6 +113,10 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
         kwargs = argsAndKwArgs$kwargs
       )
     )
+    # Tag with R class so the dispatch table generic can route by class(obj)[1]
+    # R's S3 dispatch checks class(obj)[1] to decide which method to call.
+    class(returnedObject) <- c(name, class(returnedObject))
+    returnedObject
   })
 
   rFn <- function(...) {
@@ -103,20 +136,33 @@ defineConstructor <- function(module, setGenericCallback, name, pyParams) {
   setGenericCallback(name, rFn)
 }
 
-# Define an R wrapper for a method of a Python class
+# Define an R wrapper for an instance method of a Python class.
 #
-# @param module the python module
-# @param setGenericCallback the callback to setGeneric defined in the target R package
-# @param className the name of the Python class
-# @param methodName the name of the method for R (could be camelCase)
-# @param pyParams the function info args as from getFunctionInfo
-# @param pythonMethodName the original Python method name (snake_case), if NULL uses methodName
+# Creates two functions and registers the public one via setGenericCallback:
+#
+#   .<className>_<methodName>  — private wrapper; validates `instance` is non-NULL,
+#                                splits ... into positional/keyword args, calls
+#                                gateway$invoke(instance, pythonMethodName, ...).
+#   <className>_<methodName>   — public function with formals derived from pyParams;
+#                                `self` is stripped and replaced with `instance` as
+#                                the first formal. Delegates to the private wrapper.
+#
+# @param module fully-qualified Python module string, e.g. "synapseclient.models"
+# @param setGenericCallback callback that registers the public function in the target
+#   R package namespace (typically wraps assign or setGeneric)
+# @param className Python class name, e.g. "File"; used as the prefix in the function name
+# @param methodName R-side method name (snake_case or camelCase); becomes the suffix
+#   in "<className>_<methodName>"
+# @param pyParams inspected Python signature from getFunctionInfo: list with fields
+#   args, defaults, varargs, keywords
+# @param pythonMethodName actual Python method name passed to gateway$invoke; defaults
+#   to methodName when NULL — set this when the R name and Python name differ
 defineClassMethod <- function(module, setGenericCallback, className, methodName, pyParams, pythonMethodName = NULL) {
   force(className)
   force(methodName)
   force(module)
   force(pyParams)
-  
+
   # If pythonMethodName is not provided, use methodName
   if (is.null(pythonMethodName)) {
     pythonMethodName <- methodName
@@ -126,8 +172,9 @@ defineClassMethod <- function(module, setGenericCallback, className, methodName,
   # Create a unique R function name for the class method
   rFunctionName <- sprintf("%s_%s", className, methodName)
   rWrapperName <- sprintf(".%s_%s", className, methodName)
-  
-  gateway <- reticulate::import("gateway")
+
+  gateway <- .getGateway()
+
   assign(rWrapperName, function(instance, ...) {
     if (missing(instance) || is.null(instance)) {
       stop(sprintf("The first argument must be an instance of %s", className))
@@ -159,103 +206,159 @@ defineClassMethod <- function(module, setGenericCallback, className, methodName,
     do.call(rWrapperName, args = dots)
   }
 
-  # Create formal arguments for the method, including the instance parameter
+  # Create formal arguments for the method, including a "instance" parameter
   newArgs <- .createFormalArgs(pyParams)
   if (length(newArgs) > 0) {
     # Remove 'self' from arguments if it exists and add 'instance' as first parameter
     if (!is.null(newArgs) && "self" %in% names(newArgs)) {
       newArgs <- newArgs[names(newArgs) != "self"]
     }
-    newArgs <- append(list(instance = quote(expr =)), newArgs, after = 0)
+    newArgs <- append(newArgs, list(instance = quote(expr =)), after = 0)
   } else {
     newArgs <- list(instance = quote(expr =))
   }
-  
+
   formals(rFn) <- newArgs
   setGenericCallback(rFunctionName, rFn)
 }
 
-# Define a functional R wrapper for a method of a Python class
-# This creates functions like synGetProject() that can be used with R-style piping
+# Define a functional R wrapper for a method of a Python class.
 #
-# @param module the python module
-# @param setGenericCallback the callback to setGeneric defined in the target R package
-# @param className the name of the Python class
-# @param methodName the name of the method for R (could be camelCase)
-# @param pyParams the function info args as from getFunctionInfo
-# @param pythonMethodName the original Python method name (snake_case), if NULL uses methodName
-# @param functionPrefix the prefix to add to the function name (e.g., "syn")
-# @param functionNameMapping the mapping configuration for customizing function names
-defineFunctionalClassMethod <- function(module, setGenericCallback, className, methodName, pyParams, pythonMethodName = NULL, functionPrefix = "syn", functionNameMapping = NULL) {
+# For each (className, methodName) pair this function does two things:
+#
+#   1. Registers an inner worker — a closure bound to the specific class — in
+#      .functionalMethodDispatch under the key "<genericName>_<className>".
+#      The worker accepts (instance, ...) and calls gateway$invoke with the
+#      Python object as self, forwarding all positional and keyword arguments.
+#
+#   2. Registers a single public generic (e.g. synGetAcl) in the package
+#      namespace the first time it is seen. The generic inspects class(instance)[1]
+#      at call time, looks up the matching inner worker, and delegates to it.
+#      This means one public function dispatches across all registered classes:
+#        File(...) |> synGetAcl()    # routes to synGetAcl_File worker
+#        Project(...) |> synGetAcl() # routes to synGetAcl_Project worker
+#   3. Calling the generic with no arguments — i.e. synGetAcl() with nothing
+#      piped in — triggers an explicit stop() whose message suggests the user
+#      should pass an object as the first argument.
+#   4. If the generic is called with an object whose class has no registered inner worker,
+#      it errors with "No '<genericName>' method registered for class '<className>'".
+#   5. For static methods (isStatic = TRUE) no inner worker is registered; instead a
+#      plain function is created that resolves the Python class at call time via
+#      reticulate::py_eval and invokes the method directly without an instance.
+#
+# @param module the Python module path (e.g. "synapseclient.models")
+# @param className the Python class name (e.g. "File"); used as the dispatch key suffix
+# @param methodName the method name used to derive the R function name (snake_case or camelCase)
+# @param pyParams parameter info list from getFunctionInfo: args, defaults, varargs, keywords
+# @param pythonMethodName the original Python method name if it differs from methodName; defaults to methodName
+# @param functionPrefix prefix prepended to the camelCase method name (default "syn")
+# @param functionNameMapping optional list with an $explicit named character vector for overriding generated names
+# @param isStatic if TRUE, registers a static wrapper that omits the instance argument
+defineFunctionalClassMethod <- function(module, className, methodName, pyParams, pythonMethodName = NULL, functionPrefix = "syn", functionNameMapping = NULL, isStatic = FALSE) {
+  # Capture the package namespace NOW, before any nested calls.
+  # sys.function() here = defineFunctionalClassMethod; its environment = the package namespace.
+  # Inside local({}) or any nested call, sys.function() would return a different function
+  # (e.g. local or eval), giving the wrong environment.
+  pkgNs <- environment(sys.function())
+
   force(className)
   force(methodName)
   force(module)
   force(pyParams)
   force(functionPrefix)
-  
-  # If pythonMethodName is not provided, use methodName
+  force(isStatic)
+
   if (is.null(pythonMethodName)) {
     pythonMethodName <- methodName
   }
   force(pythonMethodName)
 
-  # Create a functional R function name like synGetProject
-  defaultFunctionalName <- paste0(functionPrefix, snakeToCamel(methodName), className)
-  
-  # Apply custom mapping if provided
-  functionalRFunctionName <- applyFunctionNameMapping(
-    defaultFunctionalName, 
+  # Generic name — no class suffix. One public function per verb:
+  #   synStore(file_obj, ...)    synStore(project_obj, ...)
+  # Dispatch to the right implementation via .functionalMethodDispatch lookup.
+  genericName <- applyFunctionNameMapping(
+    paste0(functionPrefix, snakeToCamel(methodName)),
     functionNameMapping
   )
-  
-  rWrapperName <- sprintf(".%s", functionalRFunctionName)
-  
-  gateway <- reticulate::import("gateway")
-  assign(rWrapperName, function(instance, ...) {
-    if (missing(instance) || is.null(instance)) {
-      stop(sprintf("The first argument must be an instance of %s", className))
+  force(genericName)
+
+  gateway <- .getGateway()
+
+  if (isStatic) {
+    # Static methods: no instance — call directly on the Python class.
+    if (!exists(genericName, mode = "function", inherits = FALSE)) {
+      staticFn <- function(...) {
+        pyClass <- reticulate::py_eval(sprintf("%s.%s", module, className))
+        argsAndKwArgs <- determineArgsAndKwArgs(...)
+        returnedObject <- cleanUpStackTrace(gateway$invoke, list(
+          method = list(pyClass, pythonMethodName),
+          args   = argsAndKwArgs$args,
+          kwargs = argsAndKwArgs$kwargs
+        ))
+        if (grepl("GeneratorWrapper", class(returnedObject)[1])) class(returnedObject)[1] <- "GeneratorWrapper"
+        if (grepl("CsvFileTable", class(returnedObject)[1])) class(returnedObject)[1] <- "CsvFileTable"
+        returnedObject
+      }
+
+      methodArgs <- .createFormalArgs(pyParams)
+      if (!"..." %in% names(methodArgs)) {
+        methodArgs <- c(methodArgs, alist(... = ))
+      }
+      formals(staticFn) <- methodArgs
+      assign(genericName, staticFn, envir = pkgNs)
     }
+    return(invisible(NULL))
+  }
+
+  # The key for the dispatch table: "<genericName>_<className>"
+  classMethodKey <- paste0(genericName, "_", className)
+
+  # Closure stored in .functionalMethodDispatch under classMethodKey; never exposed
+  # by name in any namespace — retrieved only by the generic at dispatch time.
+  classMethodFn <- function(instance, ...) {
     argsAndKwArgs <- determineArgsAndKwArgs(...)
-    returnedObject <- cleanUpStackTrace(
-      gateway$invoke,
-      list(
-        method = list(instance, pythonMethodName),
-        args = argsAndKwArgs$args,
-        kwargs = argsAndKwArgs$kwargs
-      )
-    )
-    if (grepl("GeneratorWrapper", class(returnedObject)[1])) {
-      class(returnedObject)[1] <- "GeneratorWrapper"
-    }
-    if (grepl("CsvFileTable", class(returnedObject)[1])) {
-      class(returnedObject)[1] <- "CsvFileTable"
-    }
+    returnedObject <- cleanUpStackTrace(gateway$invoke, list(
+      method = list(instance, pythonMethodName),
+      args   = argsAndKwArgs$args,
+      kwargs = argsAndKwArgs$kwargs
+    ))
+    if (grepl("GeneratorWrapper", class(returnedObject)[1])) class(returnedObject)[1] <- "GeneratorWrapper"
+    if (grepl("CsvFileTable", class(returnedObject)[1])) class(returnedObject)[1] <- "CsvFileTable"
     returnedObject
-  })
-
-  rFn <- function(instance, ...) {
-    # formals will be assigned below, re-create the dots
-    # so we can pass them through to the py call
-    call <- sys.call()
-    call[[1]] <- as.name('list')
-    dots <- eval.parent(call)
-    do.call(rWrapperName, args = dots)
   }
 
-  # Create formal arguments for the method, including the instance parameter
-  newArgs <- .createFormalArgs(pyParams)
-  if (length(newArgs) > 0) {
-    # Remove 'self' from arguments if it exists and add 'instance' as first parameter
-    if (!is.null(newArgs) && "self" %in% names(newArgs)) {
-      newArgs <- newArgs[names(newArgs) != "self"]
+  # Assign the inner worker function to the dispatch table under the key "<genericName>_<className>"
+  assign(classMethodKey, classMethodFn, envir = .functionalMethodDispatch)
+
+  # Register the generic once as a plain function
+  if (!exists(genericName, mode = "function", inherits = TRUE)) {
+    gn  <- genericName
+    tbl <- .functionalMethodDispatch
+    genericFn <- function(instance, ...) {
+      # sys.call() captures the raw call so named formals (e.g. comment, label)
+      # are forwarded to the inner worker
+      call <- sys.call()
+      call[[1]] <- as.name('list')
+      dots <- eval.parent(call)
+      if (length(dots) == 0) {
+        stop(sprintf("Pass an object as the first argument, e.g. ClassName(...) |> %s()", gn))
+      }
+      cls <- class(dots[[1]])[1]
+      key <- paste0(gn, "_", cls)
+      if (!exists(key, envir = tbl, inherits = FALSE)) {
+        stop(sprintf("No '%s' method registered for class '%s'", gn, cls))
+      }
+      do.call(get(key, envir = tbl), args = dots)
     }
-    newArgs <- append(list(instance = quote(expr =)), newArgs, after = 0)
-  } else {
-    newArgs <- list(instance = quote(expr =))
+    # Expose method-specific formals so callers can see available params (e.g. via ?synSnapshot).
+    # instance is prepended; ... is added if not already present (handles Python *args/**kwargs methods).
+    methodArgs <- .createFormalArgs(pyParams)
+    if (!"..." %in% names(methodArgs)) {
+      methodArgs <- c(methodArgs, alist(... = ))
+    }
+    formals(genericFn) <- c(list(instance = quote(expr =)), methodArgs)
+    assign(genericName, genericFn, envir = pkgNs)
   }
-  
-  formals(rFn) <- newArgs
-  setGenericCallback(functionalRFunctionName, rFn)
 }
 
 # Helper function to generate R wrappers for classes in a python module
@@ -266,7 +369,7 @@ defineFunctionalClassMethod <- function(module, setGenericCallback, className, m
 autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
   for (c in classInfo) {
     defineConstructor(module, setGenericCallback, c$name, c$constructorArgs)
-    
+
     # Generate wrappers for class methods (excluding constructor)
     if (!is.null(c$methods)) {
       for (method in c$methods) {
@@ -288,6 +391,7 @@ autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
 # @param functionNameMapping the mapping configuration for customizing function names
 autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallback, classInfo, functionPrefix = "syn", functionNameMapping = NULL, verbose = FALSE) {
   for (c in classInfo) {
+    # suppress output when loading package
     if (nzchar(Sys.getenv("R_INSTALL_PKG"))) cat(sprintf("Creating class wrapper for: %s\n", c$name))
     defineConstructor(module, setGenericCallback, c$name, c$constructorArgs)
     
@@ -295,24 +399,43 @@ autoGenerateClassesWithFunctionalInterface <- function(module, setGenericCallbac
     if (!is.null(c$methods)) {
       for (method in c$methods) {
         # Skip the constructor method (it has the same name as the class)
-        if (method$name != c$name) {      
+        if (method$name != c$name) {
+          isStatic <- isTRUE(method$is_static)
           # Create both regular class method and functional interface
-          defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
-          defineFunctionalClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name, functionPrefix, functionNameMapping)
+          #defineClassMethod(module, setGenericCallback, c$name, method$name, method$args, method$name)
+          defineFunctionalClassMethod(module, c$name, method$name, method$args, method$name, functionPrefix, functionNameMapping, isStatic = isStatic)
         }
       }
     }
   }
 }
 
-# Define an R wrappers for a function in a python module
+# Define an R wrapper for a standalone function inside a Python module or class.
 #
-# @param rName the R function name
-# @param pyName the Python function name
-# @param functionContainerName the function container name in Python
-# @param pyParams the function info args as from getFunctionInfo
-# @param setGenericCallback the callback to setGeneric defined in the target R package
-# @param transformReturnObject optional function to change returned values in R
+# The module-level counterpart to defineClassMethod: instead of calling a method
+# on a Python instance, it calls a function on a Python module or class resolved
+# at call time via reticulate::py_eval(functionContainerName).
+#
+# Creates two functions, registering the public one via setGenericCallback:
+#
+#   .<rName>  — private wrapper; resolves the Python container, splits ... into
+#               positional/keyword args, calls gateway$invoke, applies
+#               transformReturnObject if provided.
+#   <rName>   — public function with formals derived from pyParams; delegates
+#               to the private wrapper.
+#
+# @param rName R name for the public function, e.g. "synGet"
+# @param pyName Python function name passed to gateway$invoke, e.g. "get"
+# @param functionContainerName dotted Python path to the module or class that
+#   holds the function, e.g. "synapseclient.operations"; resolved at call time
+#   via reticulate::py_eval so it is not imported until the function is invoked
+# @param pyParams inspected Python signature from getFunctionInfo: list with
+#   fields args, defaults, varargs, keywords
+# @param setGenericCallback callback that registers the public function in the
+#   target R package namespace
+# @param transformReturnObject optional function applied to the Python return
+#   value before it is returned to the caller; use to reshape raw Python objects
+#   into R-friendly types (e.g. list to data frame). NULL means pass through unchanged.
 defineFunction <- function(rName,
                            pyName,
                            functionContainerName,
@@ -324,12 +447,12 @@ defineFunction <- function(rName,
   force(functionContainerName)
   force(pyParams)
   rWrapperName <- sprintf(".%s", rName)
+  gateway <- .getGateway()
   assign(rWrapperName, function(...) {
     functionContainer <- reticulate::py_eval(functionContainerName)
     argsAndKwArgs <- determineArgsAndKwArgs(...)
-    gateway <- reticulate::import("gateway")
     returnedObject <- cleanUpStackTrace(
-      gateway$invoke,
+      gateway$invoke, # nolint: object_usage_linter
       list(
         method = list(functionContainer, pyName),
         args = argsAndKwArgs$args,
@@ -428,11 +551,7 @@ addPrefix <- function(name, prefix) {
 #
 # @param x the list to remove NULL
 removeNulls <- function(x) {
-  nullIndices <- sapply(x, is.null)
-  if (any(nullIndices)) {
-    x <- x[-which(nullIndices)]
-  }
-  x
+  Filter(Negate(is.null), x)
 }
 
 # Helper function to get a list of Python functions in a given module
@@ -447,8 +566,7 @@ getFunctionInfo <- function(pyPkg,
                             functionFilter = NULL,
                             functionPrefix = NULL,
                             pySingletonName = NULL) {
-  reticulate::py_run_string("import pyPkgInfo")
-  reticulate::py_run_string(sprintf("import %s", pyPkg))
+  .initPyPkgInfo(pyPkg)
   functionInfo <- reticulate::py_eval(sprintf("pyPkgInfo.getFunctionInfo(%s)", module))
 
   if (!is.null(functionFilter)) {
@@ -485,9 +603,7 @@ getFunctionInfo <- function(pyPkg,
 # @param module the Python module
 # @param enumFilter optional function to modify the returned Enum classes
 getEnumInfo <- function(pyPkg, module, enumFilter = NULL) {
-  reticulate::py_run_string("import sys")
-  reticulate::py_run_string("import pyPkgInfo")
-  reticulate::py_run_string(paste("import", pyPkg))
+  .initPyPkgInfo(pyPkg)
   enumInfo <- reticulate::py_eval(sprintf("pyPkgInfo.getEnumInfo(%s)", module))
   if (!is.null(enumFilter)) {
     enumInfo <- lapply(X = enumInfo, enumFilter)
@@ -502,9 +618,7 @@ getEnumInfo <- function(pyPkg, module, enumFilter = NULL) {
 # @param module the Python module
 # @param classFilter optional function to modify the returned classes
 getClassInfo <- function(pyPkg, module, classFilter = NULL) {
-  reticulate::py_run_string("import sys")
-  reticulate::py_run_string("import pyPkgInfo")
-  reticulate::py_run_string(paste("import", pyPkg))
+  .initPyPkgInfo(pyPkg)
   classInfo <- reticulate::py_eval(sprintf("pyPkgInfo.getClassInfo(%s)", module))
   if (!is.null(classFilter)) {
     classInfo <- lapply(X = classInfo, classFilter)
@@ -957,7 +1071,6 @@ autoGenerateRdFiles <- function(srcRootDir,
 # create the 'usage' section of the doc
 # this is also used to document the 'methods' of a class
 usage <- function(name, args, argDescriptionsFromDoc) {
-  result <- NULL
   argNames <- args$args
   defaults <- args$defaults
   result <- NULL
@@ -1372,33 +1485,23 @@ generateFunctionalInterfaceInfo <- function(classInfo, functionPrefix = "syn", f
       for (method in c$methods) {
         # Skip the constructor method (it has the same name as the class)
         if (method$name != c$name) {
-          # Create functional R function name like synGetProject
-          defaultFunctionalName <- paste0(functionPrefix, snakeToCamel(method$name), c$name)
-          
-          # Apply custom mapping if provided
+          # Generic name — no class suffix; dispatch table routes per class
+          defaultGenericName <- paste0(functionPrefix, snakeToCamel(method$name))
           functionalRFunctionName <- applyFunctionNameMapping(
-            defaultFunctionalName,
+            defaultGenericName,
             functionNameMapping
           )
-          
-          # Create modified args where 'self' is replaced with 'instance'
+
+          # Strip 'self' from args — instance is not a named formal
           modifiedArgs <- method$args
           if (!is.null(modifiedArgs) && "self" %in% modifiedArgs$args) {
-            # Replace 'self' with 'instance' in the args list
-            selfIndex <- which(modifiedArgs$args == "self")
-            modifiedArgs$args[selfIndex] <- "instance"
-          } else if (!is.null(modifiedArgs$args)) {
-            # Add 'instance' as first parameter if 'self' wasn't found
-            modifiedArgs$args <- c("instance", modifiedArgs$args)
-          } else {
-            # Create args structure with just 'instance'
-            modifiedArgs <- list(args = "instance", varargs = NULL, keywords = NULL, defaults = NULL)
+            modifiedArgs$args <- modifiedArgs$args[modifiedArgs$args != "self"]
           }
-          
-          # Create functional interface function info
+
           functionalFunctionInfo <- list(
             pyName = method$name,
-            rName = functionalRFunctionName,
+            rName = functionalRFunctionName,   # public generic, e.g. "synStore"
+            targetClass = c$name,              # e.g. "File" — which class this entry covers
             functionContainerName = paste0(c$name, ".", method$name),
             args = modifiedArgs,
             doc = method$doc,

--- a/R/shared.R
+++ b/R/shared.R
@@ -20,6 +20,7 @@
 # for synapseclient.Synapse
 .synapseClassFunctionFilter <- function(x) {
   if ((!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) ||
+      isTRUE(x$deprecated_todo) ||
       (any(x$name == .methodsToOmit))) {
     return(NULL)
   } else {
@@ -28,13 +29,19 @@
 }
 
 # for synapseclient module
-
 .removeAllFunctionsFunctionFilter <- function(x) NULL
 
 .classesToSkip <- c(
   "Entity",
   "Synapse",
-  "Annotations"
+  "QueryMixin",
+  "AppendableRowSetRequest",
+  "UploadToTableRequest",
+  "TableUpdateTransaction",
+  "TableSchemaChangeRequest",
+  "PartialRow",
+  "PartialRowSet",
+  "ColumnChange"
 )
 .methodsToOmit <- c(
   "postURI",
@@ -45,17 +52,60 @@
   "putACLURI",
   "keys",
   "has_key",
-  "set_annotations"
+  "set_annotations",
+  "fill_from_dict",
+  "to_synapse_request",
+  "allow_client_caching",
+  "invite_to_team"
 )
 
-.synapseClientClassFilter <- function(x) {
-  if (any(x$name == .classesToSkip)) {
-    return(NULL)
-  }
+.modelClassMethodsToOmit <- c(
+  "query",
+  "query_part_mask",
+  "format_for_manifest",
+  "from_id",
+  "from_parent",
+  "from_name",
+  "from_username"
+)
+
+# Non-async function names from synapseclient.operations; excluded from
+# model class methods since they are already wrapped via the operations
+# generateRWrappers call.
+.operationsFunctionNames <- c(
+  "delete",
+  "download_list_add",
+  "download_list_clear",
+  "download_list_files",
+  "download_list_manifest",
+  "download_list_remove",
+  "find_entity_id",
+  "get",
+  "is_synapse_id",
+  "md5_query",
+  "onweb",
+  "print_entity",
+  "store"
+)
+
+# expose synchronous functions only
+.removeAsyncFunctionFilter <- function(x) {
+  if (!endsWith(x$name, "_async")) x else NULL
+}
+# for synapseclient.models
+.synapseModelClassFilter <- function(x) {
+  if (any(x$name == .classesToSkip)) return(NULL)
   if (!is.null(x$methods)) {
     culledMethods <- lapply(X = x$methods,
-                            function(x) {
-                              if (any(x$name == .methodsToOmit)) NULL else x;
+                            function(method) {
+                              if (any(method$name == .methodsToOmit) ||
+                                  grepl("_async$", method$name) ||
+                                  any(method$name == .modelClassMethodsToOmit) ||
+                                  any(method$name == .operationsFunctionNames)) {
+                                NULL
+                              } else {
+                                method
+                              }
                             }
     )
     # Now remove the nulls
@@ -65,4 +115,20 @@
     }
   }
   x
+}
+
+
+# Helper function to get predefined function name mapping for synapseclient.models
+#
+# @return A list containing explicit mapping configuration for synapseclient.models functions
+.synapseClientModelsMapping <- function() {
+  list(
+    explicit = list(
+      "synDisassociateFromEntityActivity" = "synDisassociateActivityFromEntity",
+      "synFromPathFile" = "synGetFileFromPath",
+      "synInviteTeam" = "synInviteToTeam",
+      "synMembersTeam" = "synGetTeamMembers",
+      "synOpenInvitationsTeam" = "synGetTeamOpenInvitations"
+    )
+  )
 }

--- a/R/shared.R
+++ b/R/shared.R
@@ -17,89 +17,103 @@
 
 .removeAllClassesClassFilter <- function(x) NULL
 
-# for synapseclient.Synapse
-.synapseClassFunctionFilter <- function(x) {
-  if ((!is.null(x$doc) && regexpr("**Deprecated**", x$doc, fixed = TRUE)[1] > 0) ||
-      isTRUE(x$deprecated_todo) ||
-      (any(x$name == .methodsToOmit))) {
-    return(NULL)
-  } else {
-    x
-  }
-}
 
+# for synapseclient.Synapse
+.synapseClassMethodsToInclude <- c(
+  "login",
+  "logout",
+  "setEndpoints",
+  "sendMessage",
+  "restGET",
+  "restPUT",
+  "restPOST",
+  "restDELETE"
+)
+.synapseClassFunctionFilter <- function(x) {
+  if (any(x$name == .synapseClassMethodsToInclude)) x else NULL
+}
 # for synapseclient module
 .removeAllFunctionsFunctionFilter <- function(x) NULL
-
-.classesToSkip <- c(
-  "Entity",
-  "Synapse",
-  "QueryMixin",
-  "AppendableRowSetRequest",
-  "UploadToTableRequest",
-  "TableUpdateTransaction",
-  "TableSchemaChangeRequest",
-  "PartialRow",
-  "PartialRowSet",
-  "ColumnChange"
-)
-.methodsToOmit <- c(
-  "postURI",
-  "getURI",
-  "putURI",
-  "deleteURI",
-  "getACLURI",
-  "putACLURI",
-  "keys",
-  "has_key",
-  "set_annotations",
-  "fill_from_dict",
-  "to_synapse_request",
-  "allow_client_caching",
-  "invite_to_team"
-)
-
-.modelClassMethodsToOmit <- c(
-  "query",
-  "query_part_mask",
-  "format_for_manifest",
-  "from_id",
-  "from_parent",
-  "from_name",
-  "from_username"
-)
 
 # Non-async function names from synapseclient.operations; excluded from
 # model class methods since they are already wrapped via the operations
 # generateRWrappers call.
 .operationsFunctionNames <- c(
-  "delete",
-  "download_list_add",
-  "download_list_clear",
-  "download_list_files",
-  "download_list_manifest",
-  "download_list_remove",
-  "find_entity_id",
-  "get",
-  "is_synapse_id",
-  "md5_query",
-  "onweb",
-  "print_entity",
-  "store"
+    "get",
+    "store",
+    "delete",
+    "download_list_files",
+    "download_list_manifest",
+    "download_list_add",
+    "download_list_remove",
+    "download_list_clear",
+    "find_entity_id",
+    "is_synapse_id",
+    "md5_query",
+    "onweb",
+    "print_entity"
 )
 
+
+.modelClassMethodsToInclude <- c(
+  "Agent",
+  "AgentSession",
+  "AgentPrompt",
+  "Project",
+  "Folder",
+  "File",
+  "FileHandle",
+  "Evaluation",
+  "Submission",
+  "SubmissionBundle",
+  "SubmissionStatus",
+  "Table",
+  "Column",
+  "VirtualTable", 
+  "Dataset",
+  "DatasetCollection",
+  "EntityView",
+  "MaterializedView",
+  "SubmissionView",
+  "Activity",
+  "Team",
+  "UserProfile",
+  "CurationTask",
+  "RecordSet",
+  "Grid",
+  "Link",
+  "SchemaOrganization",
+  "JSONSchema",
+  "WikiOrderHint",
+  "WikiHistorySnapshot",
+  "WikiHeader",
+  "WikiPage",
+  "FormData"
+  )
+
+.modelClassMethodsToOmit <- c(
+  "format_for_manifest",
+  "fill_from_dict",
+  "to_synapse_request",
+  "allow_client_caching"
+)
 # expose synchronous functions only
 .removeAsyncFunctionFilter <- function(x) {
   if (!endsWith(x$name, "_async")) x else NULL
 }
+
+# for synapseclient.operations
+.operationsFunctionNamesFilter <- function(x) {
+  if (any(x$name == .operationsFunctionNames)) x else NULL
+}
+
 # for synapseclient.models
 .synapseModelClassFilter <- function(x) {
-  if (any(x$name == .classesToSkip)) return(NULL)
+  if (!any(x$name == .modelClassMethodsToInclude)) return(NULL)
   if (!is.null(x$methods)) {
     culledMethods <- lapply(X = x$methods,
                             function(method) {
-                              if (any(method$name == .methodsToOmit) ||
-                                  grepl("_async$", method$name) ||
+                              if (grepl("_async$", method$name) ||
                                   any(method$name == .modelClassMethodsToOmit) ||
                                   any(method$name == .operationsFunctionNames)) {
                                 NULL
@@ -108,11 +122,7 @@
                               }
                             }
     )
-    # Now remove the nulls
-    nullIndices <- sapply(culledMethods, is.null)
-    if (any(nullIndices)) {
-      x$methods <- culledMethods[-which(nullIndices)]
-    }
+    x$methods <- Filter(Negate(is.null), culledMethods) 
   }
   x
 }
@@ -124,11 +134,11 @@
 .synapseClientModelsMapping <- function() {
   list(
     explicit = list(
-      "synDisassociateFromEntityActivity" = "synDisassociateActivityFromEntity",
-      "synFromPathFile" = "synGetFileFromPath",
-      "synInviteTeam" = "synInviteToTeam",
-      "synMembersTeam" = "synGetTeamMembers",
-      "synOpenInvitationsTeam" = "synGetTeamOpenInvitations"
+      "synDisassociateFromEntity" = "synDisassociateActivityFromEntity",
+      "synFromPath"               = "synGetFromPath",
+      "synInvite"                 = "synInviteToTeam",
+      "synMembers"                = "synGetTeamMembers",
+      "synOpenInvitations"        = "synGetOpenInvitations"
     )
   )
 }

--- a/R/shared.R
+++ b/R/shared.R
@@ -3,6 +3,12 @@
 # Author: bhoff
 ###############################################################################
 
+# Single source of truth for the pinned synapseclient (Python) version.
+# Read directly (package namespace) by R/zzz.R, and via source() from disk
+# by tools/installPythonClient.R and tools/createRdFiles.R, which run before
+# the synapser package itself is installed.
+PYTHON_CLIENT_VERSION <- '4.12'
+
 .addPythonAndFoldersToSysPath <- function(srcDir) {
   reticulate::py_run_string("import sys")
   reticulate::py_run_string(sprintf(

--- a/R/shared.R
+++ b/R/shared.R
@@ -5,7 +5,10 @@
 
 .addPythonAndFoldersToSysPath <- function(srcDir) {
   reticulate::py_run_string("import sys")
-  reticulate::py_run_string(sprintf("sys.path.insert(0, '%s')", file.path(srcDir, "python")))
+  reticulate::py_run_string(sprintf(
+    "sys.path.insert(0, '%s')",
+    file.path(srcDir, "python")
+  ))
 }
 
 # for synapseclient.table module
@@ -24,10 +27,10 @@
   "logout",
   "setEndpoints",
   "sendMessage",
-  "restGET",
-  "restPUT",
-  "restPOST",
-  "restDELETE"
+  "rest_get_async",
+  "rest_put_async",
+  "rest_post_async",
+  "rest_delete_async"
 )
 .synapseClassFunctionFilter <- function(x) {
   if (any(x$name == .synapseClassMethodsToInclude)) x else NULL
@@ -39,37 +42,37 @@
 # model class methods since they are already wrapped via the operations
 # generateRWrappers call.
 .operationsFunctionNames <- c(
-    "get",
-    "store",
-    "delete",
-    "download_list_files",
-    "download_list_manifest",
-    "download_list_add",
-    "download_list_remove",
-    "download_list_clear",
-    "find_entity_id",
-    "is_synapse_id",
-    "md5_query",
-    "onweb",
-    "print_entity"
+  "get",
+  "store",
+  "delete",
+  "download_list_files",
+  "download_list_manifest",
+  "download_list_add",
+  "download_list_remove",
+  "download_list_clear",
+  "find_entity_id",
+  "is_synapse_id",
+  "md5_query",
+  "onweb",
+  "print_entity"
 )
 
 
-.modelClassMethodsToInclude <- c(
+.modelClassesToInclude <- c(
   "Agent",
   "AgentSession",
   "AgentPrompt",
   "Project",
   "Folder",
   "File",
-  "FileHandle",
+  #"FileHandle",
   "Evaluation",
   "Submission",
   "SubmissionBundle",
   "SubmissionStatus",
   "Table",
   "Column",
-  "VirtualTable", 
+  "VirtualTable",
   "Dataset",
   "DatasetCollection",
   "EntityView",
@@ -78,18 +81,18 @@
   "Activity",
   "Team",
   "UserProfile",
-  "CurationTask",
-  "RecordSet",
-  "Grid",
+  #"CurationTask",
+  #"RecordSet",
+  #"Grid",
   "Link",
   "SchemaOrganization",
   "JSONSchema",
   "WikiOrderHint",
   "WikiHistorySnapshot",
   "WikiHeader",
-  "WikiPage",
-  "FormData"
-  )
+  "WikiPage"
+  #"FormData"
+)
 
 .modelClassMethodsToOmit <- c(
   "format_for_manifest",
@@ -109,20 +112,22 @@
 
 # for synapseclient.models
 .synapseModelClassFilter <- function(x) {
-  if (!any(x$name == .modelClassMethodsToInclude)) return(NULL)
+  if (!any(x$name == .modelClassesToInclude)) {
+    return(NULL)
+  }
   if (!is.null(x$methods)) {
-    culledMethods <- lapply(X = x$methods,
-                            function(method) {
-                              if (grepl("_async$", method$name) ||
-                                  any(method$name == .modelClassMethodsToOmit) ||
-                                  any(method$name == .operationsFunctionNames)) {
-                                NULL
-                              } else {
-                                method
-                              }
-                            }
-    )
-    x$methods <- Filter(Negate(is.null), culledMethods) 
+    culledMethods <- lapply(X = x$methods, function(method) {
+      if (
+        grepl("_async$", method$name) ||
+          any(method$name == .modelClassMethodsToOmit) ||
+          any(method$name == .operationsFunctionNames)
+      ) {
+        NULL
+      } else {
+        method
+      }
+    })
+    x$methods <- Filter(Negate(is.null), culledMethods)
   }
   x
 }
@@ -131,14 +136,24 @@
 # Helper function to get predefined function name mapping for synapseclient.models
 #
 # @return A list containing explicit mapping configuration for synapseclient.models functions
-.synapseClientModelsMapping <- function() {
+.functionNameMappingSynapse <- function() {
+  list(
+    explicit = list(
+      "synRestGetAsync" = "synRestGet",
+      "synRestPutAsync" = "synRestPut",
+      "synRestPostAsync" = "synRestPost",
+      "synRestDeleteAsync" = "synRestDelete"
+    )
+  )
+}
+.functionNameMappingSynapseclientModels <- function() {
   list(
     explicit = list(
       "synDisassociateFromEntity" = "synDisassociateActivityFromEntity",
-      "synFromPath"               = "synGetFromPath",
-      "synInvite"                 = "synInviteToTeam",
-      "synMembers"                = "synGetTeamMembers",
-      "synOpenInvitations"        = "synGetOpenInvitations"
+      "synFromPath" = "synGetFromPath",
+      "synInvite" = "synInviteToTeam",
+      "synMembers" = "synGetTeamMembers",
+      "synOpenInvitations" = "synGetOpenInvitations"
     )
   )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,8 +4,6 @@
 ###############################################################################
 
 .onLoad <- function(libname, pkgname) {
-  PYTHON_CLIENT_VERSION <- '4.12'
-
   # Declares the requirement before any Python call so reticulate's
   # uv-managed ephemeral environment resolves it up front, instead of
   # provisioning a fresh empty environment for this process.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -55,15 +55,13 @@
                     functionFilter = .synapseClassFunctionFilter,
                     functionPrefix = "syn",
                     pySingletonName = "syn")
-  # expose synapseclient.operations
   reticulate::py_run_string("import synapseclient.operations")
   generateRWrappers(pyPkg = "synapseclient",
                     container = "synapseclient.operations",
                     setGenericCallback = .setGenericCallback,
                     assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .removeAsyncFunctionFilter,
+                    functionFilter = .operationsFunctionNamesFilter,
                     functionPrefix = "syn")
-
   generateRWrappers(pyPkg = "synapseclient.models",
                     container = "synapseclient.models",
                     setGenericCallback = .setGenericCallback,
@@ -75,23 +73,6 @@
                     functionNameMapping = .synapseClientModelsMapping()
                     )
 }
-# TODO: This section is removed since it causes the infinite recursion 
-# issue when reading downloaded entity to a dataframe. Revisit this
-# when deprecating PythonEmbedInR code
-# .objectDefinitionHelper <- function(object) {
-#   if (methods::is(object, "CsvFileTable")) {
-#     # reading from csv
-#     # Removed due to Error in unlockBinding("asDataFrame", object) : no binding for "asDataFrame"
-#     # unlockBinding("asDataFrame", object)
-#     object$asDataFrame <- function() {
-#       .readCsvBasedOnSchema(object)
-#     }
-#     # Removed due to Error in lockBinding("asDataFrame", object) : no binding for "asDataFrame"
-#     # lockBinding("asDataFrame", object)
-#   }
-#   object
-# }
-
 .onAttach <- function(libname, pkgname) {
   tou <- "\nTERMS OF USE NOTICE:
   When using Synapse, remember that the terms and conditions of use require that you:
@@ -105,7 +86,6 @@
 }
 
 .defineOverloadFunctions <- function() {
-
   methods::setClass("GeneratorWrapper")
   methods::setMethod(
     f = "as.list",
@@ -130,3 +110,4 @@
     }
   )
 }
+

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -55,23 +55,26 @@
                     functionFilter = .synapseClassFunctionFilter,
                     functionPrefix = "syn",
                     pySingletonName = "syn")
-  # exposing all supporting classes except for Synapse itself and some selected classes.
+  # expose synapseclient.operations
+  reticulate::py_run_string("import synapseclient.operations")
   generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient",
+                    container = "synapseclient.operations",
                     setGenericCallback = .setGenericCallback,
                     assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .removeAllFunctionsFunctionFilter,
-                    classFilter = .synapseClientClassFilter)
-  # cherry picking and exposing function Table
-  generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient.table",
-                    setGenericCallback = .setGenericCallback,
-                    assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .cherryPickTableFunctionFilter,
-                    classFilter = .removeAllClassesClassFilter,
+                    functionFilter = .removeAsyncFunctionFilter,
                     functionPrefix = "syn")
-}
 
+  generateRWrappers(pyPkg = "synapseclient.models",
+                    container = "synapseclient.models",
+                    setGenericCallback = .setGenericCallback,
+                    assignEnumCallback = .assignEnumCallback,
+                    functionFilter = .removeAsyncFunctionFilter,
+                    classFilter = .synapseModelClassFilter,
+                    functionPrefix = "syn",
+                    generateFunctionalInterface = TRUE,
+                    functionNameMapping = .synapseClientModelsMapping()
+                    )
+}
 # TODO: This section is removed since it causes the infinite recursion 
 # issue when reading downloaded entity to a dataframe. Revisit this
 # when deprecating PythonEmbedInR code
@@ -102,50 +105,7 @@
 }
 
 .defineOverloadFunctions <- function() {
-  methods::setGeneric(
-    name ="Table",
-    def = function(schema, values, ...){
-      do.call("synTable", args = list(schema, values, ...))
-    }
-  )
-  methods::setMethod(
-    f = "Table",
-    signature = c("character", "data.frame"),
-    definition = function(schema, values) {
-      file <- tempfile()
-      .saveToCsv(values, file)
-      Table(schema, file)
-    }
-  )
-  methods::setMethod(
-    f = "Table",
-    signature = c("ANY", "data.frame"),
-    definition = function(schema, values) {
-      file <- tempfile()
-      .saveToCsvWithSchema(schema, values, file)
-      Table(schema, file)
-    }
-  )
-  
-  methods::setMethod(
-    f = "synBuildTable",
-    signature = c("ANY", "ANY", "data.frame"),
-    definition = function(name, parent, values) {
-      file <- tempfile()
-      .saveToCsv(values, file)
-      synBuildTable(name, parent, file)
-    }
-  )
 
-  methods::setClass("CsvFileTable")
-  methods::setMethod(
-    f = "as.data.frame",
-    signature = c(x = "CsvFileTable"),
-    definition = function(x) {
-      .readCsvBasedOnSchema(x)
-    }
-  )
-  
   methods::setClass("GeneratorWrapper")
   methods::setMethod(
     f = "as.list",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,28 +13,40 @@
       # have to duplicate the synapseclient install code
       # system2(paste("Rscript ", getwd(), "/tools/installPythonClient.R ", getwd(), sep=""))
       PYTHON_CLIENT_VERSION <- 'v4.12'
-      reticulate::py_install(c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep="")), pip=T)
+      reticulate::py_install(
+        c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep = "")),
+        pip = T
+      )
       reticulate::py_run_string("import synapseclient")
     }
   )
-  
-  reticulate::py_run_string(sprintf("synapserVersion = 'synapser/%s' ", utils::packageVersion("synapser")))
-  reticulate::py_run_string("synapseclient.USER_AGENT['User-Agent'] = synapserVersion + ' '+ synapseclient.USER_AGENT['User-Agent']")
+
+  reticulate::py_run_string(sprintf(
+    "synapserVersion = 'synapser/%s' ",
+    utils::packageVersion("synapser")
+  ))
+  reticulate::py_run_string(
+    "synapseclient.USER_AGENT['User-Agent'] = synapserVersion + ' '+ synapseclient.USER_AGENT['User-Agent']"
+  )
   reticulate::py_run_string("synapseclient.core.config.single_threaded = True")
-  reticulate::py_run_string("syn=synapseclient.Synapse(skip_checks=True, debug=False)")
+  reticulate::py_run_string(
+    "syn=synapseclient.Synapse(skip_checks=True, debug=False)"
+  )
   # make syn available in the global environment
   syn <<- reticulate::py_eval("syn")
-  
+
   .addPythonAndFoldersToSysPath(system.file(package = "synapser"))
   .defineRPackageFunctions()
   # .defineOverloadFunctions() must come AFTER .defineRPackageFunctions()
   # because it redefines selected generic functions
   .defineOverloadFunctions()
-  
+
   # mute Python warnings
   reticulate::py_run_string("import warnings")
   reticulate::py_run_string("warnings.filterwarnings('ignore')")
-  reticulate::py_run_string("warnings.showwarning = lambda *args, **kwargs: None")
+  reticulate::py_run_string(
+    "warnings.showwarning = lambda *args, **kwargs: None"
+  )
 }
 
 .setGenericCallback <- function(name, def) {
@@ -48,30 +60,36 @@
 
 .defineRPackageFunctions <- function() {
   # exposing all Synapse's methods without exposing the Synapse object
-  generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient.Synapse",
-                    setGenericCallback = .setGenericCallback,
-                    assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .synapseClassFunctionFilter,
-                    functionPrefix = "syn",
-                    pySingletonName = "syn")
+  generateRWrappers(
+    pyPkg = "synapseclient",
+    container = "synapseclient.Synapse",
+    setGenericCallback = .setGenericCallback,
+    assignEnumCallback = .assignEnumCallback,
+    functionFilter = .synapseClassFunctionFilter,
+    functionPrefix = "syn",
+    pySingletonName = "syn",
+    functionNameMapping = .functionNameMappingSynapse()
+  )
   reticulate::py_run_string("import synapseclient.operations")
-  generateRWrappers(pyPkg = "synapseclient",
-                    container = "synapseclient.operations",
-                    setGenericCallback = .setGenericCallback,
-                    assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .operationsFunctionNamesFilter,
-                    functionPrefix = "syn")
-  generateRWrappers(pyPkg = "synapseclient.models",
-                    container = "synapseclient.models",
-                    setGenericCallback = .setGenericCallback,
-                    assignEnumCallback = .assignEnumCallback,
-                    functionFilter = .removeAsyncFunctionFilter,
-                    classFilter = .synapseModelClassFilter,
-                    functionPrefix = "syn",
-                    generateFunctionalInterface = TRUE,
-                    functionNameMapping = .synapseClientModelsMapping()
-                    )
+  generateRWrappers(
+    pyPkg = "synapseclient",
+    container = "synapseclient.operations",
+    setGenericCallback = .setGenericCallback,
+    assignEnumCallback = .assignEnumCallback,
+    functionFilter = .operationsFunctionNamesFilter,
+    functionPrefix = "syn"
+  )
+  generateRWrappers(
+    pyPkg = "synapseclient.models",
+    container = "synapseclient.models",
+    setGenericCallback = .setGenericCallback,
+    assignEnumCallback = .assignEnumCallback,
+    functionFilter = .removeAsyncFunctionFilter,
+    classFilter = .synapseModelClassFilter,
+    functionPrefix = "syn",
+    generateFunctionalInterface = TRUE,
+    functionNameMapping = .functionNameMappingSynapseclientModels()
+  )
 }
 .onAttach <- function(libname, pkgname) {
   tou <- "\nTERMS OF USE NOTICE:
@@ -80,7 +98,7 @@
   2) Not discriminate, identify, or recontact individuals or groups represented by the data.
   3) Use and contribute only data de-identified to HIPAA standards.
   4) Redistribute data only under these same terms of use.\n"
-  
+
   .checkForUpdate()
   packageStartupMessage(tou)
 }
@@ -94,14 +112,14 @@
       x$asList()
     }
   )
-  
+
   methods::setGeneric(
     name = "nextElem",
     def = function(x) {
       standardGeneric("nextElem")
     }
   )
-  
+
   methods::setMethod(
     f = "nextElem",
     signature = c(x = "GeneratorWrapper"),
@@ -110,4 +128,3 @@
     }
   )
 }
-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,15 +4,23 @@
 ###############################################################################
 
 .onLoad <- function(libname, pkgname) {
+  PYTHON_CLIENT_VERSION <- '4.12'
+
+  # Declares the requirement before any Python call so reticulate's
+  # uv-managed ephemeral environment resolves it up front, instead of
+  # provisioning a fresh empty environment for this process.
+  reticulate::py_require(
+    paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep = "")
+  )
+
   tryCatch(
     {
       reticulate::py_run_string("import synapseclient")
     },
     error = function(e) {
-      # Ideally we would source tools/installPythonClient.R to not
-      # have to duplicate the synapseclient install code
-      # system2(paste("Rscript ", getwd(), "/tools/installPythonClient.R ", getwd(), sep=""))
-      PYTHON_CLIENT_VERSION <- 'v4.12'
+      # Fallback for when Python was already initialized (e.g. a
+      # persistent venv via RETICULATE_PYTHON) before py_require() above
+      # could take effect.
       reticulate::py_install(
         c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep = "")),
         pip = T

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -2,7 +2,7 @@ import types
 from abbreviateStackTrace import abbreviateStackTrace
 from patchStdoutStdErr import patch_stdout_stderr
 
-
+# TODO: This class is might be redundant if using reticulate::iter_next() / reticulate::iterate()
 class GeneratorWrapper:
     def __init__(self, wrapped):
         self._inner = wrapped

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -37,8 +37,8 @@ def invoke(**kwargs):
 
     Expects kwargs with keys:
       - method: a (object, method_name) tuple identifying the callable
-      - args: positional arguments (numeric strings are coerced to numbers)
-      - kwargs: keyword arguments (numeric strings are coerced to numbers)
+      - args: positional arguments
+      - kwargs: keyword arguments
 
     Returns the result of the method call, wrapped by generatorModifier to
     handle generator/iterator return values, and abbreviateStackTrace to

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -32,29 +32,21 @@ def generatorModifier(g):
         return g
 
 
-def _coerce_numeric(obj):
-    """Recursively convert whole-number R doubles (e.g. 1.0) to Python ints.
-
-    reticulate passes R numeric vectors as Python floats. Many Synapse API
-    parameters (version_number, principal_id, …) expect int/Long. This avoids
-    requiring callers to write 1L in R everywhere since R passes bare 1 to Python
-    as a double (1.0), but the Synapse API expects a Long. 
-    """
-    if isinstance(obj, float) and obj.is_integer():
-        return int(obj)
-    if isinstance(obj, (list, tuple)):
-        coerced = (_coerce_numeric(x) for x in obj)
-        return type(obj)(coerced)
-    if isinstance(obj, dict):
-        return {k: _coerce_numeric(v) for k, v in obj.items()}
-    return obj
-
-
-# expects a dict with the keys: method (a list of [object, method name]), args, and kwargs
 def invoke(**kwargs):
+    """Invoke a Python method from R via the reticulate bridge.
+
+    Expects kwargs with keys:
+      - method: a (object, method_name) tuple identifying the callable
+      - args: positional arguments (numeric strings are coerced to numbers)
+      - kwargs: keyword arguments (numeric strings are coerced to numbers)
+
+    Returns the result of the method call, wrapped by generatorModifier to
+    handle generator/iterator return values, and abbreviateStackTrace to
+    produce R-friendly tracebacks on error.
+    """
     patch_stdout_stderr()
     method = kwargs["method"]
-    args = _coerce_numeric(kwargs["args"])
-    kw = _coerce_numeric(dict(kwargs["kwargs"]))
+    args = kwargs["args"]
+    kw = dict(kwargs["kwargs"])
     method_to_call = getattr(method[0], method[1])
     return generatorModifier(abbreviateStackTrace(lambda: method_to_call(*args, **kw)))

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -1,27 +1,27 @@
 import types
 from abbreviateStackTrace import abbreviateStackTrace
 from patchStdoutStdErr import patch_stdout_stderr
-from synapseclient.annotations import Annotations
 
-class GeneratorWrapper():
+
+class GeneratorWrapper:
     def __init__(self, wrapped):
-       self._inner = wrapped
-       self._use_list = False
-       self._use_iter = False
+        self._inner = wrapped
+        self._use_list = False
+        self._use_iter = False
 
     def nextElem(self):
-      if self._use_list:
-        raise Exception("Have already enumerated all elements.")
-      self._use_iter = True
-      return self._inner.__next__()
+        if self._use_list:
+            raise Exception("Have already enumerated all elements.")
+        self._use_iter = True
+        return self._inner.__next__()
 
     def asList(self):
-      if self._use_iter:
-        raise Exception("Can't generate a list once enumeration has begun.")
-      if self._use_list:
-        raise Exception("Have already enumerated all elements.")
-      self._use_list = True
-      return list(self._inner)
+        if self._use_iter:
+            raise Exception("Can't generate a list once enumeration has begun.")
+        if self._use_list:
+            raise Exception("Have already enumerated all elements.")
+        self._use_list = True
+        return list(self._inner)
 
 # from https://stackoverflow.com/questions/972/adding-a-method-to-an-existing-object-instance#2982
 def generatorModifier(g):
@@ -31,20 +31,12 @@ def generatorModifier(g):
     else:
         return g
 
-def annotationsModifier(a):
-    # convert to a simple dictionary
-    if isinstance(a, Annotations):
-        return a.copy()
-    else:
-        return a
 
 # expects a dict with the keys: method (a list of [object, method name]), args, and kwargs
 def invoke(**kwargs):
     patch_stdout_stderr()
-    method = kwargs['method']
-    args = kwargs['args']
-    kw = dict(kwargs['kwargs'])
+    method = kwargs["method"]
+    args = kwargs["args"]
+    kw = dict(kwargs["kwargs"])
     method_to_call = getattr(method[0], method[1])
-    return annotationsModifier(generatorModifier(abbreviateStackTrace(lambda: method_to_call(*args, **kw))))
-
-
+    return generatorModifier(abbreviateStackTrace(lambda: method_to_call(*args, **kw)))

--- a/inst/python/gateway.py
+++ b/inst/python/gateway.py
@@ -32,11 +32,29 @@ def generatorModifier(g):
         return g
 
 
+def _coerce_numeric(obj):
+    """Recursively convert whole-number R doubles (e.g. 1.0) to Python ints.
+
+    reticulate passes R numeric vectors as Python floats. Many Synapse API
+    parameters (version_number, principal_id, …) expect int/Long. This avoids
+    requiring callers to write 1L in R everywhere since R passes bare 1 to Python
+    as a double (1.0), but the Synapse API expects a Long. 
+    """
+    if isinstance(obj, float) and obj.is_integer():
+        return int(obj)
+    if isinstance(obj, (list, tuple)):
+        coerced = (_coerce_numeric(x) for x in obj)
+        return type(obj)(coerced)
+    if isinstance(obj, dict):
+        return {k: _coerce_numeric(v) for k, v in obj.items()}
+    return obj
+
+
 # expects a dict with the keys: method (a list of [object, method name]), args, and kwargs
 def invoke(**kwargs):
     patch_stdout_stderr()
     method = kwargs["method"]
-    args = kwargs["args"]
-    kw = dict(kwargs["kwargs"])
+    args = _coerce_numeric(kwargs["args"])
+    kw = _coerce_numeric(dict(kwargs["kwargs"]))
     method_to_call = getattr(method[0], method[1])
     return generatorModifier(abbreviateStackTrace(lambda: method_to_call(*args, **kw)))

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -1,11 +1,36 @@
 import inspect
-# import gateway
+import sys
+from typing import Protocol
+
+
+def is_method_from_protocol(method_func, class_definition) -> bool:
+    """
+    Check if a method comes from a Protocol class or mixin by examining the MRO
+    and looking for classes that define this method and are part of the
+    synapseclient protocol/mixin system.
+    """
+    if Protocol is None:
+        return False
+
+    method_name = method_func.__name__
+
+    for base_class in class_definition.__mro__:
+        if base_class is class_definition or base_class is object:
+            continue
+
+        if (issubclass(base_class, Protocol) and
+                method_name in base_class.__dict__ and
+                callable(getattr(base_class, method_name, None))):
+            return True
+
+    return False
+
 
 def isFunctionOrRoutine(member):
     return inspect.isfunction(member) or inspect.isroutine(member)
 
+
 def argspecContent(fn):
-    # follow_wrapped since we generally are not concerned about decorators
     fn_signature = inspect.signature(fn, follow_wrapped=True)
 
     args = []
@@ -29,17 +54,156 @@ def argspecContent(fn):
         'defaults': tuple(defaults),
     }
 
-def getCleanedDoc(member):
-    doc = inspect.getdoc(member)
-    if doc is None:
+
+def getCleanedDoc(member, class_context=None):
+    """
+    Extract and clean docstrings from a member, collecting all docstrings
+    found at any level of wrapped functions.
+
+    Args:
+        member: The function/method to extract docstring from
+        class_context: The class that the member belongs to (if applicable)
+    """
+
+    if (hasattr(member, '__module__') and
+            'synapseclient.models' not in member.__module__):
+        doc = inspect.getdoc(member)
+        if doc:
+            return inspect.cleandoc(doc)
+
+    all_docstrings = []
+
+    def _find_protocol_method_docstring(func):
+        """Find the docstring from the Protocol class."""
+        func_name = getattr(func, '__name__', '')
+
+        target_class = None
+
+        if class_context is not None:
+            target_class = class_context
+
+        elif hasattr(func, '__self__') and func.__self__ is not None:
+            target_class = func.__self__.__class__
+
+        elif hasattr(func, '__qualname__') and '.' in func.__qualname__:
+            parts = func.__qualname__.split('.')
+            if len(parts) >= 2:
+                class_name = parts[0]
+
+                if hasattr(func, '__module__'):
+                    module = sys.modules.get(func.__module__)
+                    if module and hasattr(module, class_name):
+                        potential_class = getattr(module, class_name)
+                        if inspect.isclass(potential_class):
+                            target_class = potential_class
+
+        if target_class is None and hasattr(func, '__module__'):
+            for module_name, module in sys.modules.items():
+                if (module and
+                        'synapseclient.models' in module_name and
+                        hasattr(module, '__dict__')):
+                    for attr_name, attr_value in module.__dict__.items():
+                        if (inspect.isclass(attr_value) and
+                                hasattr(attr_value, func_name) and
+                                callable(getattr(attr_value, func_name))):
+                            target_class = attr_value
+                            break
+                if target_class:
+                    break
+
+        if target_class is None:
+            return None
+
+        def _search_protocol_in_class_hierarchy(cls, method_name,
+                                                visited=None):
+            """Recursively search for Protocol method docstring."""
+            if visited is None:
+                visited = set()
+
+            if cls in visited:
+                return None
+            visited.add(cls)
+
+            for base_class in cls.__mro__:
+                if base_class is cls or base_class is object:
+                    continue
+
+                is_protocol_class = issubclass(base_class, Protocol)
+
+                if is_protocol_class:
+                    if (method_name in base_class.__dict__ and
+                            callable(getattr(base_class, method_name, None))):
+                        protocol_method = getattr(base_class, method_name)
+                        protocol_doc = inspect.getdoc(protocol_method)
+                        if protocol_doc:
+                            return protocol_doc
+
+                elif (hasattr(base_class, '__mro__') and
+                      len(base_class.__mro__) > 2):
+                    result = _search_protocol_in_class_hierarchy(
+                        base_class, method_name, visited)
+                    if result:
+                        return result
+
+            return None
+
+        protocol_doc = _search_protocol_in_class_hierarchy(
+            target_class, func_name)
+        if protocol_doc:
+            return protocol_doc
+
+        for module_name, module in sys.modules.items():
+            if module and hasattr(module, '__dict__'):
+                for attr_name, attr_value in module.__dict__.items():
+                    if (inspect.isclass(attr_value) and
+                            Protocol and
+                            attr_value is not Protocol):
+                        if issubclass(attr_value, Protocol):
+                            if (hasattr(attr_value, func_name) and
+                                    callable(getattr(
+                                        attr_value, func_name))):
+                                protocol_method = getattr(
+                                    attr_value, func_name)
+                                protocol_doc = inspect.getdoc(
+                                    protocol_method)
+                                if protocol_doc:
+                                    return protocol_doc
+
         return None
-    else:
-        return inspect.cleandoc(doc)
+
+    async_marker = 'The new method that will replace the non-async method'
+    if (hasattr(member, '__name__') and
+            hasattr(member, '__module__') and
+            ('async_to_sync' in str(type(member)) or
+             (inspect.getdoc(member) and
+              async_marker in inspect.getdoc(member)))):
+
+        protocol_doc = _find_protocol_method_docstring(member)
+        if protocol_doc and protocol_doc not in all_docstrings:
+            all_docstrings.insert(0, protocol_doc)
+
+    if not all_docstrings:
+        if (hasattr(member, '__module__') and
+                'synapseclient.models' in member.__module__):
+            doc = inspect.getdoc(member)
+            if doc:
+                return inspect.cleandoc(doc)
+
+        return None
+
+    for doc in all_docstrings:
+        if doc and async_marker not in doc:
+            return inspect.cleandoc(doc)
+
+    return inspect.cleandoc(all_docstrings[0])
+
 
 def methodAttributes(name, method):
     args = argspecContent(method)
     cleaneddoc = getCleanedDoc(method)
-    return({'name':name, 'args':args, 'doc':cleaneddoc, 'module':method.__module__})
+    return ({'name': name, 'args': args, 'doc': cleaneddoc,
+             'module': method.__module__})
+
 
 def getFunctionInfo(module):
     result = []
@@ -51,41 +215,168 @@ def getFunctionInfo(module):
         result.append(methodAttributes(name, method))
     return result
 
+
 def getEnumInfo(module):
+    import ast
+
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        if name != "Enum" and str(type(classdefinition))=="<class 'enum.EnumMeta'>":
+        if (name != "Enum" and
+                (str(type(classdefinition)) == "<class 'enum.EnumMeta'>" or
+                 str(type(classdefinition)) == "<class 'enum.EnumType'>")):
+
             enumValues = inspect.getmembers(classdefinition)
-            enumValues = [item for item in enumValues if (not item[0].startswith('_') and item[0] not in ['name', 'value'])]
+            enumValues = [item for item in enumValues if (
+                not item[0].startswith('_') and
+                item[0] not in ['name', 'value'])]
             keys = [x[0] for x in enumValues]
             values = [x[1] for x in enumValues]
-            result.append({'name':name, 'keys':keys, 'values':values})
+
+            attribute_docs = {}
+            if hasattr(module, '__file__') and module.__file__:
+                with open(module.__file__, 'r') as f:
+                    source = f.read()
+
+                tree = ast.parse(source)
+
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.ClassDef) and node.name == name:
+                        for i, item in enumerate(node.body):
+                            if isinstance(item, ast.Assign):
+                                for target in item.targets:
+                                    if isinstance(target, ast.Name):
+                                        attr_name = target.id
+
+                                        next_idx = i + 1
+                                        has_docstring = (
+                                            next_idx < len(node.body) and
+                                            isinstance(node.body[next_idx],
+                                                       ast.Expr) and
+                                            isinstance(
+                                                node.body[next_idx].value,
+                                                ast.Constant) and
+                                            isinstance(
+                                                node.body[next_idx]
+                                                .value.value, str))
+
+                                        if has_docstring:
+                                            next_node = node.body[next_idx]
+                                            docstring = next_node.value.value
+                                            attribute_docs[attr_name] = (
+                                                inspect.cleandoc(docstring))
+                        break
+
+            enum_result = {
+                'name': name,
+                'keys': keys,
+                'values': values
+            }
+
+            if attribute_docs:
+                enum_result['attribute_docs'] = attribute_docs
+
+            result.append(enum_result)
     return result
+
 
 def getClassInfo(module):
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        constructorArgs=None
+        constructorArgs = None
         methods = []
-        # let's go through all the functions
-        for classmember in inspect.getmembers(classdefinition, inspect.isfunction):
+        for classmember in inspect.getmembers(classdefinition,
+                                              inspect.isfunction):
             methodName = classmember[0]
-            if methodName=='__init__':
+            if methodName == '__init__':
                 constructorArgs = argspecContent(classmember[1])
-            elif (not methodName.startswith("_")) and classmember[1].__module__==classdefinition.__module__:
-                # this is a non-private, non-inherited function defined in the class
-                methodArgs = argspecContent(classmember[1])
-                methodDescription = getCleanedDoc(classmember[1])
-                methods.append({'name':methodName, 'doc':methodDescription, 'args':methodArgs})
+            elif (not methodName.startswith("_")) and (
+                classmember[1].__module__ == classdefinition.__module__ or
+                is_method_from_protocol(classmember[1], classdefinition)
+            ):
+                if is_async_to_sync_wrapper(classmember[1]):
+                    protocol_args, protocol_doc = find_protocol_method_info(
+                        methodName, classdefinition)
+                    if protocol_args is not None and protocol_doc is not None:
+                        methodArgs = protocol_args
+                        methodDescription = protocol_doc
+                    else:
+                        methodArgs = argspecContent(classmember[1])
+                        methodDescription = getCleanedDoc(
+                            classmember[1], class_context=classdefinition)
+                else:
+                    methodArgs = argspecContent(classmember[1])
+                    methodDescription = getCleanedDoc(
+                        classmember[1], class_context=classdefinition)
+
+                methods.append({'name': methodName,
+                                'doc': methodDescription,
+                                'args': methodArgs})
         if constructorArgs is None:
             continue
         cleaneddoc = getCleanedDoc(classdefinition)
-        # insert the constructor itself as the first thing in the list
-        methods.insert(0, {'name':name, 'doc':cleaneddoc, 'args':constructorArgs})
-        result.append({'name':name, 'constructorArgs':constructorArgs, 'doc':cleaneddoc, 'methods':methods})
+        methods.insert(
+            0, {'name': name, 'doc': cleaneddoc, 'args': constructorArgs})
+        result.append({'name': name, 'constructorArgs': constructorArgs,
+                      'doc': cleaneddoc, 'methods': methods})
     return result
 
+
+def is_async_to_sync_wrapper(method_func):
+    """
+    Check if a method is an async_to_sync wrapper by examining its module,
+    qualname, and docstring.
+    """
+    if (not hasattr(method_func, '__module__') or
+            not hasattr(method_func, '__qualname__')):
+        return False
+
+    if 'synapseclient.core.async_utils' not in method_func.__module__:
+        return False
+
+    if 'async_to_sync' in method_func.__qualname__:
+        return True
+
+    doc = inspect.getdoc(method_func)
+    if doc and 'The new method that will replace the non-async method' in doc:
+        return True
+
+    return False
+
+
+def find_protocol_method_info(method_name, class_definition):
+    """
+    Find the protocol method information for a given method name in the
+    class hierarchy.
+    Returns a tuple of (args_info, docstring) or (None, None) if not found.
+    """
+    if Protocol is None:
+        return None, None
+
+    for base_class in class_definition.__mro__:
+        if base_class is class_definition or base_class is object:
+            continue
+
+        is_protocol_class = issubclass(base_class, Protocol)
+
+        if is_protocol_class:
+            if (hasattr(base_class, '__module__') and
+                    base_class.__module__ and
+                    'mixins' in base_class.__module__):
+                continue
+
+            if (method_name in base_class.__dict__ and
+                    callable(getattr(base_class, method_name, None))):
+                protocol_method = getattr(base_class, method_name)
+                protocol_doc = inspect.getdoc(protocol_method)
+
+                if (protocol_doc and
+                        ('The new method that will replace the ' +
+                         'non-async method') not in protocol_doc):
+                    protocol_args = argspecContent(protocol_method)
+                    return protocol_args, protocol_doc
+
+    return None, None

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -2,6 +2,9 @@ import inspect
 import sys
 from typing import Protocol
 
+# Placeholder text injected by async_to_sync into wrapper docstrings.
+_ASYNC_TO_SYNC_MARKER = 'The new method that will replace the non-async method'
+
 
 def is_method_from_protocol(method_func, class_definition) -> bool:
     """
@@ -27,10 +30,26 @@ def is_method_from_protocol(method_func, class_definition) -> bool:
 
 
 def isFunctionOrRoutine(member):
+    """Check if a member is a function or routine.
+
+    Args:
+        member: The function or routine to check.
+
+    Returns:
+        True if the member is a function or routine, False otherwise.
+    """
     return inspect.isfunction(member) or inspect.isroutine(member)
 
 
 def argspecContent(fn):
+    """Get the argument specification for a function.
+
+    Args:
+        fn: The function to get the argument specification for.
+
+    Returns:
+        A dictionary containing the argument specification.
+    """
     fn_signature = inspect.signature(fn, follow_wrapped=True)
 
     args = []
@@ -55,155 +74,167 @@ def argspecContent(fn):
     }
 
 
-def getCleanedDoc(member, class_context=None):
-    """
-    Extract and clean docstrings from a member, collecting all docstrings
-    found at any level of wrapped functions.
+def _is_synapse_model_member(member):
+    """Check if a member is a member of the synapseclient.models module.
 
     Args:
-        member: The function/method to extract docstring from
-        class_context: The class that the member belongs to (if applicable)
+        member: The member to check.
+
+    Returns:
+        True if the member is a member of the synapseclient.models module, False otherwise.
     """
+    return (hasattr(member, '__module__') and
+            'synapseclient.models' in member.__module__)
 
-    if (hasattr(member, '__module__') and
-            'synapseclient.models' not in member.__module__):
-        doc = inspect.getdoc(member)
-        if doc:
-            return inspect.cleandoc(doc)
 
-    all_docstrings = []
+def _resolve_owner_class(func, class_context):
+    """
+    Determine the class that owns `func`, used to seed a Protocol search. 
+    If the class_context is not provided, the class that owns the function is returned.
 
-    def _find_protocol_method_docstring(func):
-        """Find the docstring from the Protocol class."""
-        func_name = getattr(func, '__name__', '')
+    Tries four strategies in priority order:
+      1. caller-supplied class_context — always pass this when known; async_to_sync
+         wrappers have a __qualname__ of the form
+         "async_to_sync.<locals>.create_method.<locals>.newmethod" that encodes no
+         class name, so strategies 2–3 will fail and strategy 4 (full sys.modules
+         scan) kicks in for every method unless class_context short-circuits it.
+      2. bound method's __self__.__class__
+      3. parse __qualname__ and look up the class in its own module
+      4. scan synapseclient.models modules for any class that has the method
+    """
+    if class_context is not None:
+        return class_context
 
-        target_class = None
+    if hasattr(func, '__self__') and func.__self__ is not None:
+        return func.__self__.__class__
 
-        if class_context is not None:
-            target_class = class_context
+    if hasattr(func, '__qualname__') and '.' in func.__qualname__:
+        class_name = func.__qualname__.split('.')[0]
+        module = sys.modules.get(getattr(func, '__module__', ''), None)
+        if module:
+            candidate = getattr(module, class_name, None)
+            if inspect.isclass(candidate):
+                return candidate
 
-        elif hasattr(func, '__self__') and func.__self__ is not None:
-            target_class = func.__self__.__class__
+    func_name = getattr(func, '__name__', '')
+    for module_name, module in sys.modules.items():
+        if not (module and 'synapseclient.models' in module_name):
+            continue
+        for attr in module.__dict__.values():
+            if (inspect.isclass(attr) and
+                    hasattr(attr, func_name) and
+                    callable(getattr(attr, func_name))):
+                return attr
 
-        elif hasattr(func, '__qualname__') and '.' in func.__qualname__:
-            parts = func.__qualname__.split('.')
-            if len(parts) >= 2:
-                class_name = parts[0]
+    return None
 
-                if hasattr(func, '__module__'):
-                    module = sys.modules.get(func.__module__)
-                    if module and hasattr(module, class_name):
-                        potential_class = getattr(module, class_name)
-                        if inspect.isclass(potential_class):
-                            target_class = potential_class
 
-        if target_class is None and hasattr(func, '__module__'):
-            for module_name, module in sys.modules.items():
-                if (module and
-                        'synapseclient.models' in module_name and
-                        hasattr(module, '__dict__')):
-                    for attr_name, attr_value in module.__dict__.items():
-                        if (inspect.isclass(attr_value) and
-                                hasattr(attr_value, func_name) and
-                                callable(getattr(attr_value, func_name))):
-                            target_class = attr_value
-                            break
-                if target_class:
-                    break
-
-        if target_class is None:
-            return None
-
-        def _search_protocol_in_class_hierarchy(cls, method_name,
-                                                visited=None):
-            """Recursively search for Protocol method docstring."""
-            if visited is None:
-                visited = set()
-
-            if cls in visited:
-                return None
-            visited.add(cls)
-
-            for base_class in cls.__mro__:
-                if base_class is cls or base_class is object:
-                    continue
-
-                is_protocol_class = issubclass(base_class, Protocol)
-
-                if is_protocol_class:
-                    if (method_name in base_class.__dict__ and
-                            callable(getattr(base_class, method_name, None))):
-                        protocol_method = getattr(base_class, method_name)
-                        protocol_doc = inspect.getdoc(protocol_method)
-                        if protocol_doc:
-                            return protocol_doc
-
-                elif (hasattr(base_class, '__mro__') and
-                      len(base_class.__mro__) > 2):
-                    result = _search_protocol_in_class_hierarchy(
-                        base_class, method_name, visited)
-                    if result:
-                        return result
-
-            return None
-
-        protocol_doc = _search_protocol_in_class_hierarchy(
-            target_class, func_name)
-        if protocol_doc:
-            return protocol_doc
-
-        for module_name, module in sys.modules.items():
-            if module and hasattr(module, '__dict__'):
-                for attr_name, attr_value in module.__dict__.items():
-                    if (inspect.isclass(attr_value) and
-                            Protocol and
-                            attr_value is not Protocol):
-                        if issubclass(attr_value, Protocol):
-                            if (hasattr(attr_value, func_name) and
-                                    callable(getattr(
-                                        attr_value, func_name))):
-                                protocol_method = getattr(
-                                    attr_value, func_name)
-                                protocol_doc = inspect.getdoc(
-                                    protocol_method)
-                                if protocol_doc:
-                                    return protocol_doc
-
-        return None
-
-    async_marker = 'The new method that will replace the non-async method'
-    if (hasattr(member, '__name__') and
-            hasattr(member, '__module__') and
-            ('async_to_sync' in str(type(member)) or
-             (inspect.getdoc(member) and
-              async_marker in inspect.getdoc(member)))):
-
-        protocol_doc = _find_protocol_method_docstring(member)
-        if protocol_doc and protocol_doc not in all_docstrings:
-            all_docstrings.insert(0, protocol_doc)
-
-    if not all_docstrings:
-        if (hasattr(member, '__module__') and
-                'synapseclient.models' in member.__module__):
-            doc = inspect.getdoc(member)
+def _find_protocol_doc_in_mro(cls, method_name):
+    """
+    Walk the MRO of `cls` and return the first docstring found on a Protocol
+    base class that defines `method_name`. Returns None if not found.
+    """
+    for base in cls.__mro__:
+        if base is cls or base is object:
+            continue
+        try:
+            is_proto = issubclass(base, Protocol)
+        except TypeError:
+            continue
+        if (is_proto and
+                method_name in base.__dict__ and
+                callable(getattr(base, method_name, None))):
+            doc = inspect.getdoc(getattr(base, method_name))
             if doc:
-                return inspect.cleandoc(doc)
+                return doc
+    return None
 
-        return None
 
-    for doc in all_docstrings:
-        if doc and async_marker not in doc:
-            return inspect.cleandoc(doc)
+def _find_protocol_docstring(func, class_context):
+    """
+    Return the Protocol-sourced docstring for a member.
 
-    return inspect.cleandoc(all_docstrings[0])
+    Searches the owner class's MRO first (fast path). The slow fallback —
+    scanning all loaded modules — is only reached when the owner class cannot
+    be resolved at all; if the class was found but has no Protocol doc for this
+    method, the method simply isn't Protocol-defined and None is returned early.
+    """
+    func_name = getattr(func, '__name__', '')
+    owner_class = _resolve_owner_class(func, class_context)
+
+    if owner_class is not None:
+        return _find_protocol_doc_in_mro(owner_class, func_name)
+
+    for module in sys.modules.values():
+        if not (module and hasattr(module, '__dict__')):
+            continue
+        for attr in module.__dict__.values():
+            if not inspect.isclass(attr) or attr is Protocol:
+                continue
+            try:
+                is_proto = issubclass(attr, Protocol)
+            except TypeError:
+                continue
+            if (is_proto and
+                    hasattr(attr, func_name) and
+                    callable(getattr(attr, func_name))):
+                doc = inspect.getdoc(getattr(attr, func_name))
+                if doc:
+                    return doc
+
+    return None
+
+
+def getCleanedDoc(member, class_context=None):
+    """
+    Return the cleaned docstring for a member.
+
+    For non-model members the member's own docstring is returned directly.
+    For synapseclient.models members, the Protocol class docstring is preferred
+    (it is the authoritative source for generated sync wrappers); the member's
+    own docstring is used as a fallback when no Protocol doc is found.
+
+    Args:
+        member: The function/method to extract a docstring from.
+        class_context: The class that owns the member. Passing this avoids an
+            expensive module scan when looking up the Protocol hierarchy.
+    """
+    if not _is_synapse_model_member(member):
+        doc = inspect.getdoc(member)
+        return inspect.cleandoc(doc) if doc else None
+
+    if not inspect.isclass(member):
+        protocol_doc = _find_protocol_docstring(member, class_context)
+        if protocol_doc:
+            return inspect.cleandoc(protocol_doc)
+
+    doc = inspect.getdoc(member)
+    return inspect.cleandoc(doc) if doc else None
 
 def methodAttributes(name, method):
+    """Collect the name, signature, docstring, and module for a single method.
+
+    Args:
+        name: The method name as it appears on the class.
+        method: The callable to inspect.
+
+    Returns:
+        A dict with keys ``name``, ``args``, ``doc``, and ``module``.
+    """
     args = argspecContent(method)
     cleaneddoc = getCleanedDoc(method)
     return ({'name': name, 'args': args, 'doc': cleaneddoc,
              'module': method.__module__})
 
 def getFunctionInfo(module):
+    """Get the function information for a module.
+
+    Args:
+        module: The module to get the function information for.
+
+    Returns:
+        A list of dictionaries containing the function information.
+    """
     result = []
     for member in inspect.getmembers(module, isFunctionOrRoutine):
         name = member[0]
@@ -215,6 +246,14 @@ def getFunctionInfo(module):
 
 
 def getEnumInfo(module):
+    """Get the enum information for a module.
+
+    Args:
+        module: The module to get the enum information for.
+
+    Returns:
+        A list of dictionaries containing the enum information.
+    """
     import ast
 
     result = []
@@ -280,6 +319,14 @@ def getEnumInfo(module):
 
 
 def getClassInfo(module):
+    """Get the class information for a module.
+
+    Args:
+        module: The module to get the class information for.
+
+    Returns:
+        A list of dictionaries containing the class information.
+    """
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
@@ -347,7 +394,7 @@ def is_async_to_sync_wrapper(method_func):
         return True
 
     doc = inspect.getdoc(method_func)
-    if doc and 'The new method that will replace the non-async method' in doc:
+    if doc and _ASYNC_TO_SYNC_MARKER in doc:
         return True
 
     return False
@@ -401,9 +448,7 @@ def find_protocol_method_info(method_name, class_definition):
                 protocol_method = getattr(base_class, method_name)
                 protocol_doc = inspect.getdoc(protocol_method)
 
-                if (protocol_doc and
-                        ('The new method that will replace the ' +
-                         'non-async method') not in protocol_doc):
+                if protocol_doc:
                     protocol_args = argspecContent(protocol_method)
                     return protocol_args, protocol_doc
 

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -91,7 +91,7 @@ def getFunctionInfo(module):
         result.append(method_attributes(name, method))
     return result
 
-
+# TODO: to visit when working on https://sagebionetworks.jira.com/browse/SYNR-1550
 def getEnumInfo(module):
     """Get the enum information for a module.
 

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -251,13 +251,3 @@ def _is_static_in_mro(method_name, class_definition):
             return True
     return False
 
-
-def _get_static_method_func(method_name, class_definition):
-    """Return the underlying function from the first @staticmethod in the MRO."""
-    for cls in class_definition.__mro__:
-        raw = inspect.getattr_static(cls, method_name, None)
-        if isinstance(raw, staticmethod):
-            return raw.__func__
-    return None
-
-

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -198,11 +198,39 @@ def getCleanedDoc(member, class_context=None):
     return inspect.cleandoc(all_docstrings[0])
 
 
+_source_line_cache = {}
+
+
+def _get_source_lines(filepath):
+    if filepath not in _source_line_cache:
+        try:
+            with open(filepath) as f:
+                _source_line_cache[filepath] = f.readlines()
+        except OSError:
+            _source_line_cache[filepath] = []
+    return _source_line_cache[filepath]
+
+
+def _has_deprecation_todo(method):
+    try:
+        _, start_line = inspect.getsourcelines(method)
+        filepath = inspect.getfile(method)
+        lines = _get_source_lines(filepath)
+        # start_line is 1-indexed; check up to 3 lines before the def
+        for i in range(max(0, start_line - 4), start_line - 1):
+            if "# TODO: Deprecate method" in lines[i]:
+                return True
+    except (OSError, TypeError):
+        pass
+    return False
+
+
 def methodAttributes(name, method):
     args = argspecContent(method)
     cleaneddoc = getCleanedDoc(method)
     return ({'name': name, 'args': args, 'doc': cleaneddoc,
-             'module': method.__module__})
+             'module': method.__module__,
+             'deprecated_todo': _has_deprecation_todo(method)})
 
 
 def getFunctionInfo(module):

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -197,41 +197,11 @@ def getCleanedDoc(member, class_context=None):
 
     return inspect.cleandoc(all_docstrings[0])
 
-
-_source_line_cache = {}
-
-
-def _get_source_lines(filepath):
-    if filepath not in _source_line_cache:
-        try:
-            with open(filepath) as f:
-                _source_line_cache[filepath] = f.readlines()
-        except OSError:
-            _source_line_cache[filepath] = []
-    return _source_line_cache[filepath]
-
-
-def _has_deprecation_todo(method):
-    try:
-        _, start_line = inspect.getsourcelines(method)
-        filepath = inspect.getfile(method)
-        lines = _get_source_lines(filepath)
-        # start_line is 1-indexed; check up to 3 lines before the def
-        for i in range(max(0, start_line - 4), start_line - 1):
-            if "# TODO: Deprecate method" in lines[i]:
-                return True
-    except (OSError, TypeError):
-        pass
-    return False
-
-
 def methodAttributes(name, method):
     args = argspecContent(method)
     cleaneddoc = getCleanedDoc(method)
     return ({'name': name, 'args': args, 'doc': cleaneddoc,
-             'module': method.__module__,
-             'deprecated_todo': _has_deprecation_todo(method)})
-
+             'module': method.__module__})
 
 def getFunctionInfo(module):
     result = []

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -2,10 +2,6 @@ import inspect
 import sys
 from typing import Protocol
 
-# Placeholder text injected by async_to_sync into wrapper docstrings.
-_ASYNC_TO_SYNC_MARKER = 'The new method that will replace the non-async method'
-
-
 def is_method_from_protocol(method_func, class_definition) -> bool:
     """
     Check if a method comes from a Protocol class or mixin by examining the MRO
@@ -29,7 +25,7 @@ def is_method_from_protocol(method_func, class_definition) -> bool:
     return False
 
 
-def isFunctionOrRoutine(member):
+def is_function_or_routine(member):
     """Check if a member is a function or routine.
 
     Args:
@@ -41,7 +37,7 @@ def isFunctionOrRoutine(member):
     return inspect.isfunction(member) or inspect.isroutine(member)
 
 
-def argspecContent(fn):
+def argspec_content(fn):
     """Get the argument specification for a function.
 
     Args:
@@ -185,7 +181,7 @@ def _find_protocol_docstring(func, class_context):
     return None
 
 
-def getCleanedDoc(member, class_context=None):
+def get_cleaned_doc(member, class_context=None):
     """
     Return the cleaned docstring for a member.
 
@@ -211,7 +207,7 @@ def getCleanedDoc(member, class_context=None):
     doc = inspect.getdoc(member)
     return inspect.cleandoc(doc) if doc else None
 
-def methodAttributes(name, method):
+def method_attributes(name, method):
     """Collect the name, signature, docstring, and module for a single method.
 
     Args:
@@ -221,8 +217,8 @@ def methodAttributes(name, method):
     Returns:
         A dict with keys ``name``, ``args``, ``doc``, and ``module``.
     """
-    args = argspecContent(method)
-    cleaneddoc = getCleanedDoc(method)
+    args = argspec_content(method)
+    cleaneddoc = get_cleaned_doc(method)
     return ({'name': name, 'args': args, 'doc': cleaneddoc,
              'module': method.__module__})
 
@@ -236,12 +232,12 @@ def getFunctionInfo(module):
         A list of dictionaries containing the function information.
     """
     result = []
-    for member in inspect.getmembers(module, isFunctionOrRoutine):
+    for member in inspect.getmembers(module, is_function_or_routine):
         name = member[0]
         if name.startswith("_"):
             continue
         method = member[1]
-        result.append(methodAttributes(name, method))
+        result.append(method_attributes(name, method))
     return result
 
 
@@ -337,7 +333,7 @@ def getClassInfo(module):
                                               inspect.isfunction):
             methodName = classmember[0]
             if methodName == '__init__':
-                constructorArgs = argspecContent(classmember[1])
+                constructorArgs = argspec_content(classmember[1])
             elif (not methodName.startswith("_")) and (
                 classmember[1].__module__ == classdefinition.__module__ or
                 is_method_from_protocol(classmember[1], classdefinition)
@@ -349,12 +345,12 @@ def getClassInfo(module):
                         methodArgs = protocol_args
                         methodDescription = protocol_doc
                     else:
-                        methodArgs = argspecContent(classmember[1])
-                        methodDescription = getCleanedDoc(
+                        methodArgs = argspec_content(classmember[1])
+                        methodDescription = get_cleaned_doc(
                             classmember[1], class_context=classdefinition)
                 else:
-                    methodArgs = argspecContent(classmember[1])
-                    methodDescription = getCleanedDoc(
+                    methodArgs = argspec_content(classmember[1])
+                    methodDescription = get_cleaned_doc(
                         classmember[1], class_context=classdefinition)
 
                 is_static = _is_static_in_mro(methodName, classdefinition)
@@ -363,14 +359,14 @@ def getClassInfo(module):
                     # bypassing any async_to_sync (*args, **kwargs) wrapper.
                     static_fn = _get_static_method_func(methodName, classdefinition)
                     if static_fn is not None:
-                        methodArgs = argspecContent(static_fn)
+                        methodArgs = argspec_content(static_fn)
                 methods.append({'name': methodName,
                                 'doc': methodDescription,
                                 'args': methodArgs,
                                 'is_static': is_static})
         if constructorArgs is None:
             continue
-        cleaneddoc = getCleanedDoc(classdefinition)
+        cleaneddoc = get_cleaned_doc(classdefinition)
         methods.insert(
             0, {'name': name, 'doc': cleaneddoc, 'args': constructorArgs})
         result.append({'name': name, 'constructorArgs': constructorArgs,
@@ -434,7 +430,7 @@ def find_protocol_method_info(method_name, class_definition):
                 protocol_doc = inspect.getdoc(protocol_method)
 
                 if protocol_doc:
-                    protocol_args = argspecContent(protocol_method)
+                    protocol_args = argspec_content(protocol_method)
                     return protocol_args, protocol_doc
 
     return None, None

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -2,28 +2,6 @@ import inspect
 import sys
 from typing import Protocol
 
-def is_method_from_protocol(method_func, class_definition) -> bool:
-    """
-    Check if a method comes from a Protocol class or mixin by examining the MRO
-    and looking for classes that define this method and are part of the
-    synapseclient protocol/mixin system.
-    """
-    if Protocol is None:
-        return False
-
-    method_name = method_func.__name__
-
-    for base_class in class_definition.__mro__:
-        if base_class is class_definition or base_class is object:
-            continue
-
-        if (issubclass(base_class, Protocol) and
-                method_name in base_class.__dict__ and
-                callable(getattr(base_class, method_name, None))):
-            return True
-
-    return False
-
 
 def is_function_or_routine(member):
     """Check if a member is a function or routine.
@@ -63,149 +41,22 @@ def argspec_content(fn):
                 defaults.append(param.default)
 
     return {
-        'args': args,
-        'varargs': varargs,
-        'keywords': keywords,
-        'defaults': tuple(defaults),
+        "args": args,
+        "varargs": varargs,
+        "keywords": keywords,
+        "defaults": tuple(defaults),
     }
 
 
-def _is_synapse_model_member(member):
-    """Check if a function/method is a member of the synapseclient.models module.
+def get_cleaned_doc(member):
+    """Return the cleaned docstring for a member.
 
     Args:
         member: The function/method to extract a docstring from.
-
-    Returns:
-        True if the member is a member of the synapseclient.models module, False otherwise.
     """
-    return (hasattr(member, '__module__') and
-            'synapseclient.models' in member.__module__)
-
-
-def _resolve_owner_class(func, class_context):
-    """
-    Determine the class that owns `func`, used to seed a Protocol search. 
-    If the class_context is not provided, the class that owns the function is returned.
-
-    Tries four strategies in priority order:
-      1. caller-supplied class_context — always pass this when known; async_to_sync
-         wrappers have a __qualname__ of the form
-         "async_to_sync.<locals>.create_method.<locals>.newmethod" that encodes no
-         class name, so strategies 2–3 will fail and strategy 4 (full sys.modules
-         scan) kicks in for every method unless class_context short-circuits it.
-      2. bound method's __self__.__class__
-      3. parse __qualname__ and look up the class in its own module
-      4. scan synapseclient.models modules for any class that has the method
-    """
-    if class_context is not None:
-        return class_context
-
-    if hasattr(func, '__self__') and func.__self__ is not None:
-        return func.__self__.__class__
-
-    if hasattr(func, '__qualname__') and '.' in func.__qualname__:
-        class_name = func.__qualname__.split('.')[0]
-        module = sys.modules.get(getattr(func, '__module__', ''), None)
-        if module:
-            candidate = getattr(module, class_name, None)
-            if inspect.isclass(candidate):
-                return candidate
-
-    func_name = getattr(func, '__name__', '')
-    for module_name, module in sys.modules.items():
-        if not (module and 'synapseclient.models' in module_name):
-            continue
-        for attr in module.__dict__.values():
-            if (inspect.isclass(attr) and
-                    hasattr(attr, func_name) and
-                    callable(getattr(attr, func_name))):
-                return attr
-
-    return None
-
-
-def _find_protocol_doc_in_mro(cls, method_name):
-    """
-    Walk the MRO of `cls` and return the first docstring found on a Protocol
-    base class that defines `method_name`. Returns None if not found.
-    """
-    for base in cls.__mro__:
-        if base is cls or base is object:
-            continue
-        try:
-            is_proto = issubclass(base, Protocol)
-        except TypeError:
-            continue
-        if (is_proto and
-                method_name in base.__dict__ and
-                callable(getattr(base, method_name, None))):
-            doc = inspect.getdoc(getattr(base, method_name))
-            if doc:
-                return doc
-    return None
-
-
-def _find_protocol_docstring(func, class_context):
-    """
-    Return the Protocol-sourced docstring for a member.
-
-    Searches the owner class's MRO first (fast path). The slow fallback —
-    scanning all loaded modules — is only reached when the owner class cannot
-    be resolved at all; if the class was found but has no Protocol doc for this
-    method, the method simply isn't Protocol-defined and None is returned early.
-    """
-    func_name = getattr(func, '__name__', '')
-    owner_class = _resolve_owner_class(func, class_context)
-
-    if owner_class is not None:
-        return _find_protocol_doc_in_mro(owner_class, func_name)
-
-    for module in sys.modules.values():
-        if not (module and hasattr(module, '__dict__')):
-            continue
-        for attr in module.__dict__.values():
-            if not inspect.isclass(attr) or attr is Protocol:
-                continue
-            try:
-                is_proto = issubclass(attr, Protocol)
-            except TypeError:
-                continue
-            if (is_proto and
-                    hasattr(attr, func_name) and
-                    callable(getattr(attr, func_name))):
-                doc = inspect.getdoc(getattr(attr, func_name))
-                if doc:
-                    return doc
-
-    return None
-
-
-def get_cleaned_doc(member, class_context=None):
-    """
-    Return the cleaned docstring for a member.
-
-    For non-model members the member's own docstring is returned directly.
-    For synapseclient.models members, the Protocol class docstring is preferred
-    (it is the authoritative source for generated sync wrappers); the member's
-    own docstring is used as a fallback when no Protocol doc is found.
-
-    Args:
-        member: The function/method to extract a docstring from.
-        class_context: The class that owns the member. Passing this avoids an
-            expensive module scan when looking up the Protocol hierarchy.
-    """
-    if not _is_synapse_model_member(member):
-        doc = inspect.getdoc(member)
-        return inspect.cleandoc(doc) if doc else None
-
-    if not inspect.isclass(member):
-        protocol_doc = _find_protocol_docstring(member, class_context)
-        if protocol_doc:
-            return inspect.cleandoc(protocol_doc)
-
     doc = inspect.getdoc(member)
     return inspect.cleandoc(doc) if doc else None
+
 
 def method_attributes(name, method):
     """Collect the name, signature, docstring, and module for a single method.
@@ -219,8 +70,8 @@ def method_attributes(name, method):
     """
     args = argspec_content(method)
     cleaneddoc = get_cleaned_doc(method)
-    return ({'name': name, 'args': args, 'doc': cleaneddoc,
-             'module': method.__module__})
+    return {"name": name, "args": args, "doc": cleaneddoc, "module": method.__module__}
+
 
 def getFunctionInfo(module):
     """Get the function information for a module.
@@ -256,20 +107,23 @@ def getEnumInfo(module):
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        if (name != "Enum" and
-                (str(type(classdefinition)) == "<class 'enum.EnumMeta'>" or
-                 str(type(classdefinition)) == "<class 'enum.EnumType'>")):
+        if name != "Enum" and (
+            str(type(classdefinition)) == "<class 'enum.EnumMeta'>"
+            or str(type(classdefinition)) == "<class 'enum.EnumType'>"
+        ):
 
             enumValues = inspect.getmembers(classdefinition)
-            enumValues = [item for item in enumValues if (
-                not item[0].startswith('_') and
-                item[0] not in ['name', 'value'])]
+            enumValues = [
+                item
+                for item in enumValues
+                if (not item[0].startswith("_") and item[0] not in ["name", "value"])
+            ]
             keys = [x[0] for x in enumValues]
             values = [x[1] for x in enumValues]
 
             attribute_docs = {}
-            if hasattr(module, '__file__') and module.__file__:
-                with open(module.__file__, 'r') as f:
+            if hasattr(module, "__file__") and module.__file__:
+                with open(module.__file__, "r") as f:
                     source = f.read()
 
                 tree = ast.parse(source)
@@ -284,31 +138,30 @@ def getEnumInfo(module):
 
                                         next_idx = i + 1
                                         has_docstring = (
-                                            next_idx < len(node.body) and
-                                            isinstance(node.body[next_idx],
-                                                       ast.Expr) and
-                                            isinstance(
-                                                node.body[next_idx].value,
-                                                ast.Constant) and
-                                            isinstance(
-                                                node.body[next_idx]
-                                                .value.value, str))
+                                            next_idx < len(node.body)
+                                            and isinstance(
+                                                node.body[next_idx], ast.Expr
+                                            )
+                                            and isinstance(
+                                                node.body[next_idx].value, ast.Constant
+                                            )
+                                            and isinstance(
+                                                node.body[next_idx].value.value, str
+                                            )
+                                        )
 
                                         if has_docstring:
                                             next_node = node.body[next_idx]
                                             docstring = next_node.value.value
                                             attribute_docs[attr_name] = (
-                                                inspect.cleandoc(docstring))
+                                                inspect.cleandoc(docstring)
+                                            )
                         break
 
-            enum_result = {
-                'name': name,
-                'keys': keys,
-                'values': values
-            }
+            enum_result = {"name": name, "keys": keys, "values": values}
 
             if attribute_docs:
-                enum_result['attribute_docs'] = attribute_docs
+                enum_result["attribute_docs"] = attribute_docs
 
             result.append(enum_result)
     return result
@@ -329,29 +182,26 @@ def getClassInfo(module):
         classdefinition = member[1]
         constructorArgs = None
         methods = []
-        for classmember in inspect.getmembers(classdefinition,
-                                              inspect.isfunction):
+        for classmember in inspect.getmembers(classdefinition, inspect.isfunction):
             methodName = classmember[0]
-            if methodName == '__init__':
+            if methodName == "__init__":
                 constructorArgs = argspec_content(classmember[1])
             elif (not methodName.startswith("_")) and (
-                classmember[1].__module__ == classdefinition.__module__ or
-                is_method_from_protocol(classmember[1], classdefinition)
+                classmember[1].__module__ == classdefinition.__module__
             ):
                 if is_async_to_sync_wrapper(methodName, classdefinition):
-                    protocol_args, protocol_doc = find_protocol_method_info(
-                        methodName, classdefinition)
-                    if protocol_args is not None and protocol_doc is not None:
-                        methodArgs = protocol_args
-                        methodDescription = protocol_doc
+                    async_method = getattr(classdefinition, methodName + "_async", None)
+                    if async_method is not None:
+                        methodArgs = argspec_content(async_method)
+                        methodDescription = inspect.cleandoc(
+                            inspect.getdoc(async_method) or ""
+                        )
                     else:
                         methodArgs = argspec_content(classmember[1])
-                        methodDescription = get_cleaned_doc(
-                            classmember[1], class_context=classdefinition)
+                        methodDescription = get_cleaned_doc(classmember[1])
                 else:
                     methodArgs = argspec_content(classmember[1])
-                    methodDescription = get_cleaned_doc(
-                        classmember[1], class_context=classdefinition)
+                    methodDescription = get_cleaned_doc(classmember[1])
 
                 is_static = _is_static_in_mro(methodName, classdefinition)
                 if is_static:
@@ -360,26 +210,37 @@ def getClassInfo(module):
                     static_fn = _get_static_method_func(methodName, classdefinition)
                     if static_fn is not None:
                         methodArgs = argspec_content(static_fn)
-                methods.append({'name': methodName,
-                                'doc': methodDescription,
-                                'args': methodArgs,
-                                'is_static': is_static})
+                methods.append(
+                    {
+                        "name": methodName,
+                        "doc": methodDescription,
+                        "args": methodArgs,
+                        "is_static": is_static,
+                    }
+                )
         if constructorArgs is None:
             continue
         cleaneddoc = get_cleaned_doc(classdefinition)
-        methods.insert(
-            0, {'name': name, 'doc': cleaneddoc, 'args': constructorArgs})
-        result.append({'name': name, 'constructorArgs': constructorArgs,
-                      'doc': cleaneddoc, 'methods': methods})
+        methods.insert(0, {"name": name, "doc": cleaneddoc, "args": constructorArgs})
+        result.append(
+            {
+                "name": name,
+                "constructorArgs": constructorArgs,
+                "doc": cleaneddoc,
+                "methods": methods,
+            }
+        )
     return result
 
 
 def is_async_to_sync_wrapper(method_name, class_definition):
     """A method is an async_to_sync wrapper if the class defines a
-    coroutine method named {method_name}_async (see async_to_sync)."""
+    coroutine method named {method_name}_async."""
     async_sibling = inspect.getattr_static(
-        class_definition, method_name + "_async", None)
+        class_definition, method_name + "_async", None
+    )
     return inspect.iscoroutinefunction(async_sibling)
+
 
 def _is_static_in_mro(method_name, class_definition):
     """Check if a method is declared as @staticmethod anywhere in the MRO.
@@ -396,41 +257,9 @@ def _is_static_in_mro(method_name, class_definition):
 
 
 def _get_static_method_func(method_name, class_definition):
-    """Return the underlying function from the first @staticmethod in the MRO.
-
-    This lets argspecContent read the real signature rather than the
-    (*args, **kwargs) wrapper that async_to_sync generates.
-    """
+    """Return the underlying function from the first @staticmethod in the MRO."""
     for cls in class_definition.__mro__:
         raw = inspect.getattr_static(cls, method_name, None)
         if isinstance(raw, staticmethod):
             return raw.__func__
     return None
-
-
-def find_protocol_method_info(method_name, class_definition):
-    """
-    Find the protocol method information for a given method name in the
-    class hierarchy.
-    Returns a tuple of (args_info, docstring) or (None, None) if not found.
-    """
-    if Protocol is None:
-        return None, None
-
-    for base_class in class_definition.__mro__:
-        if base_class is class_definition or base_class is object:
-            continue
-
-        is_protocol_class = issubclass(base_class, Protocol)
-
-        if is_protocol_class:
-            if (method_name in base_class.__dict__ and
-                    callable(getattr(base_class, method_name, None))):
-                protocol_method = getattr(base_class, method_name)
-                protocol_doc = inspect.getdoc(protocol_method)
-
-                if protocol_doc:
-                    protocol_args = argspec_content(protocol_method)
-                    return protocol_args, protocol_doc
-
-    return None, None

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -93,80 +93,18 @@ def getFunctionInfo(module):
 
 # TODO: to visit when working on https://sagebionetworks.jira.com/browse/SYNR-1550
 def getEnumInfo(module):
-    """Get the enum information for a module.
-
-    Args:
-        module: The module to get the enum information for.
-
-    Returns:
-        A list of dictionaries containing the enum information.
-    """
-    import ast
-
     result = []
     for member in inspect.getmembers(module, inspect.isclass):
         name = member[0]
         classdefinition = member[1]
-        if name != "Enum" and (
-            str(type(classdefinition)) == "<class 'enum.EnumMeta'>"
-            or str(type(classdefinition)) == "<class 'enum.EnumType'>"
-        ):
-
+        if name != "Enum" and str(type(classdefinition))=="<class 'enum.EnumMeta'>":
             enumValues = inspect.getmembers(classdefinition)
-            enumValues = [
-                item
-                for item in enumValues
-                if (not item[0].startswith("_") and item[0] not in ["name", "value"])
-            ]
+            enumValues = [item for item in enumValues if (not item[0].startswith('_') and item[0] not in ['name', 'value'])]
             keys = [x[0] for x in enumValues]
             values = [x[1] for x in enumValues]
-
-            attribute_docs = {}
-            if hasattr(module, "__file__") and module.__file__:
-                with open(module.__file__, "r") as f:
-                    source = f.read()
-
-                tree = ast.parse(source)
-
-                for node in ast.walk(tree):
-                    if isinstance(node, ast.ClassDef) and node.name == name:
-                        for i, item in enumerate(node.body):
-                            if isinstance(item, ast.Assign):
-                                for target in item.targets:
-                                    if isinstance(target, ast.Name):
-                                        attr_name = target.id
-
-                                        next_idx = i + 1
-                                        has_docstring = (
-                                            next_idx < len(node.body)
-                                            and isinstance(
-                                                node.body[next_idx], ast.Expr
-                                            )
-                                            and isinstance(
-                                                node.body[next_idx].value, ast.Constant
-                                            )
-                                            and isinstance(
-                                                node.body[next_idx].value.value, str
-                                            )
-                                        )
-
-                                        if has_docstring:
-                                            next_node = node.body[next_idx]
-                                            docstring = next_node.value.value
-                                            attribute_docs[attr_name] = (
-                                                inspect.cleandoc(docstring)
-                                            )
-                        break
-
-            enum_result = {"name": name, "keys": keys, "values": values}
-
-            if attribute_docs:
-                enum_result["attribute_docs"] = attribute_docs
-
-            result.append(enum_result)
+            result.append({'name':name, 'keys':keys, 'values':values})
     return result
-
-
+    
 def getClassInfo(module):
     """Get the class information for a module.
 

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -342,7 +342,7 @@ def getClassInfo(module):
                 classmember[1].__module__ == classdefinition.__module__ or
                 is_method_from_protocol(classmember[1], classdefinition)
             ):
-                if is_async_to_sync_wrapper(classmember[1]):
+                if is_async_to_sync_wrapper(methodName, classdefinition):
                     protocol_args, protocol_doc = find_protocol_method_info(
                         methodName, classdefinition)
                     if protocol_args is not None and protocol_doc is not None:
@@ -378,27 +378,12 @@ def getClassInfo(module):
     return result
 
 
-def is_async_to_sync_wrapper(method_func):
-    """
-    Check if a method is an async_to_sync wrapper by examining its module,
-    qualname, and docstring.
-    """
-    if (not hasattr(method_func, '__module__') or
-            not hasattr(method_func, '__qualname__')):
-        return False
-
-    if 'synapseclient.core.async_utils' not in method_func.__module__:
-        return False
-
-    if 'async_to_sync' in method_func.__qualname__:
-        return True
-
-    doc = inspect.getdoc(method_func)
-    if doc and _ASYNC_TO_SYNC_MARKER in doc:
-        return True
-
-    return False
-
+def is_async_to_sync_wrapper(method_name, class_definition):
+    """A method is an async_to_sync wrapper if the class defines a
+    coroutine method named {method_name}_async (see async_to_sync)."""
+    async_sibling = inspect.getattr_static(
+        class_definition, method_name + "_async", None)
+    return inspect.iscoroutinefunction(async_sibling)
 
 def _is_static_in_mro(method_name, class_definition):
     """Check if a method is declared as @staticmethod anywhere in the MRO.

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -340,9 +340,17 @@ def getClassInfo(module):
                     methodDescription = getCleanedDoc(
                         classmember[1], class_context=classdefinition)
 
+                is_static = _is_static_in_mro(methodName, classdefinition)
+                if is_static:
+                    # Get the signature from the raw @staticmethod descriptor,
+                    # bypassing any async_to_sync (*args, **kwargs) wrapper.
+                    static_fn = _get_static_method_func(methodName, classdefinition)
+                    if static_fn is not None:
+                        methodArgs = argspecContent(static_fn)
                 methods.append({'name': methodName,
                                 'doc': methodDescription,
-                                'args': methodArgs})
+                                'args': methodArgs,
+                                'is_static': is_static})
         if constructorArgs is None:
             continue
         cleaneddoc = getCleanedDoc(classdefinition)
@@ -375,6 +383,33 @@ def is_async_to_sync_wrapper(method_func):
     return False
 
 
+def _is_static_in_mro(method_name, class_definition):
+    """Check if a method is declared as @staticmethod anywhere in the MRO.
+
+    async_to_sync replaces @staticmethod descriptors with ClassOrInstance
+    wrappers, so a direct inspect.getattr_static check on the class is not
+    sufficient — we need to walk the full MRO.
+    """
+    for cls in class_definition.__mro__:
+        raw = inspect.getattr_static(cls, method_name, None)
+        if isinstance(raw, staticmethod):
+            return True
+    return False
+
+
+def _get_static_method_func(method_name, class_definition):
+    """Return the underlying function from the first @staticmethod in the MRO.
+
+    This lets argspecContent read the real signature rather than the
+    (*args, **kwargs) wrapper that async_to_sync generates.
+    """
+    for cls in class_definition.__mro__:
+        raw = inspect.getattr_static(cls, method_name, None)
+        if isinstance(raw, staticmethod):
+            return raw.__func__
+    return None
+
+
 def find_protocol_method_info(method_name, class_definition):
     """
     Find the protocol method information for a given method name in the
@@ -391,11 +426,6 @@ def find_protocol_method_info(method_name, class_definition):
         is_protocol_class = issubclass(base_class, Protocol)
 
         if is_protocol_class:
-            if (hasattr(base_class, '__module__') and
-                    base_class.__module__ and
-                    'mixins' in base_class.__module__):
-                continue
-
             if (method_name in base_class.__dict__ and
                     callable(getattr(base_class, method_name, None))):
                 protocol_method = getattr(base_class, method_name)

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -186,10 +186,9 @@ def getClassInfo(module):
             methodName = classmember[0]
             if methodName == "__init__":
                 constructorArgs = argspec_content(classmember[1])
-            elif (not methodName.startswith("_")) and (
-                classmember[1].__module__ == classdefinition.__module__
-            ):
+            elif not methodName.startswith("_"):
                 if is_async_to_sync_wrapper(methodName, classdefinition):
+                    is_static = _is_static_in_mro(methodName + "_async", classdefinition)
                     async_method = getattr(classdefinition, methodName + "_async", None)
                     if async_method is not None:
                         methodArgs = argspec_content(async_method)
@@ -200,16 +199,9 @@ def getClassInfo(module):
                         methodArgs = argspec_content(classmember[1])
                         methodDescription = get_cleaned_doc(classmember[1])
                 else:
+                    is_static = _is_static_in_mro(methodName, classdefinition)
                     methodArgs = argspec_content(classmember[1])
                     methodDescription = get_cleaned_doc(classmember[1])
-
-                is_static = _is_static_in_mro(methodName, classdefinition)
-                if is_static:
-                    # Get the signature from the raw @staticmethod descriptor,
-                    # bypassing any async_to_sync (*args, **kwargs) wrapper.
-                    static_fn = _get_static_method_func(methodName, classdefinition)
-                    if static_fn is not None:
-                        methodArgs = argspec_content(static_fn)
                 methods.append(
                     {
                         "name": methodName,
@@ -239,6 +231,10 @@ def is_async_to_sync_wrapper(method_name, class_definition):
     async_sibling = inspect.getattr_static(
         class_definition, method_name + "_async", None
     )
+    # if the async sibling is declared as @staticmethod, 
+    # a staticmethod object (descriptor) is returned, not the underlying function.
+    if isinstance(async_sibling, staticmethod):
+        async_sibling = async_sibling.__func__
     return inspect.iscoroutinefunction(async_sibling)
 
 
@@ -263,3 +259,5 @@ def _get_static_method_func(method_name, class_definition):
         if isinstance(raw, staticmethod):
             return raw.__func__
     return None
+
+

--- a/inst/python/pyPkgInfo.py
+++ b/inst/python/pyPkgInfo.py
@@ -75,10 +75,10 @@ def argspecContent(fn):
 
 
 def _is_synapse_model_member(member):
-    """Check if a member is a member of the synapseclient.models module.
+    """Check if a function/method is a member of the synapseclient.models module.
 
     Args:
-        member: The member to check.
+        member: The function/method to extract a docstring from.
 
     Returns:
         True if the member is a member of the synapseclient.models module, False otherwise.

--- a/tests/test_pyPkgInfo.py
+++ b/tests/test_pyPkgInfo.py
@@ -1,0 +1,457 @@
+"""Unit tests for inst/python/pyPkgInfo.py"""
+
+import inspect
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../inst/python"))
+
+from pyPkgInfo import (
+    _get_static_method_func,
+    _is_static_in_mro,
+    argspec_content,
+    get_cleaned_doc,
+    getClassInfo,
+    getFunctionInfo,
+    is_async_to_sync_wrapper,
+    method_attributes,
+)
+
+
+class legacy_synapse_class:
+    """Legacy Synapse class."""
+
+    def __init__(self, x, y=0):
+        """Init SimpleClass."""
+        self.x = x
+
+    def public_method(self, a):
+        """A public method."""
+        return a
+
+    def _private_method(self):
+        pass
+
+    @staticmethod
+    def static_method(self, c):
+        """Static method."""
+        return c + 1
+
+
+class synapse_model_class:
+    """Synapse model class."""
+
+    def __init__(self):
+        pass
+
+    async def get_async(self, a):
+        """Async get function."""
+
+    def get(self, a):
+        """Sync wrapper for get_async method."""
+
+    @staticmethod
+    def static_method(c, d):
+        """Static method."""
+        return c + d
+
+
+# ===========================================================================
+# argspec_content
+# ===========================================================================
+
+
+class TestArgspecContent:
+    def test_no_args(self):
+        def fn():
+            pass
+
+        assert argspec_content(fn) == {
+            "args": [],
+            "varargs": None,
+            "keywords": None,
+            "defaults": (),
+        }
+
+    def test_positional_args_only(self):
+        def fn(a, b, c):
+            pass
+
+        r = argspec_content(fn)
+        assert r["args"] == ["a", "b", "c"]
+        assert r["defaults"] == ()
+        assert r["varargs"] is None
+        assert r["keywords"] is None
+
+    def test_mixed(self):
+        def fn(a, b=2, *args, **kwargs):
+            pass
+
+        r = argspec_content(fn)
+        assert r["args"] == ["a", "b"]
+        assert r["defaults"] == (2,)
+        assert r["varargs"] == "args"
+        assert r["keywords"] == "kwargs"
+
+    def test_varargs_not_in_args_list(self):
+        def fn(a, *rest, **kw):
+            pass
+
+        r = argspec_content(fn)
+        assert r["args"] == ["a"]
+        assert r["varargs"] == "rest"
+        assert r["keywords"] == "kw"
+        assert r["defaults"] == ()
+
+
+# ===========================================================================
+# get_cleaned_doc
+# ===========================================================================
+
+
+class TestGetCleanedDoc:
+    def test_with_docstring(self):
+        def fn():
+            """Simple docstring."""
+
+        assert get_cleaned_doc(fn) == "Simple docstring."
+
+    def test_without_docstring(self):
+        def fn():
+            pass
+
+        assert get_cleaned_doc(fn) is None
+
+    def test_multiline_docstring(self):
+        def fn():
+            """First line.
+
+            Second paragraph.
+            """
+
+        doc = get_cleaned_doc(fn)
+        assert doc == "First line.\n\nSecond paragraph."
+
+    def test_indented_docstring_cleaned(self):
+        def fn():
+            """
+            Indented content.
+            More content.
+            """
+
+        doc = get_cleaned_doc(fn)
+        assert doc == "Indented content.\nMore content."
+
+
+# ===========================================================================
+# method_attributes
+# ===========================================================================
+
+
+class TestMethodAttributes:
+    def test_returns_method_metadata(self):
+        def fn(a, b=2):
+            """Docstring."""
+
+        result = method_attributes("custom_name", fn)
+
+        assert result == {
+            "name": "custom_name",
+            "args": {
+                "args": ["a", "b"],
+                "varargs": None,
+                "keywords": None,
+                "defaults": (2,),
+            },
+            "doc": "Docstring.",
+            "module": fn.__module__,
+        }
+
+    def test_doc_is_none_for_undocumented_method(self):
+        def fn():
+            pass
+
+        result = method_attributes("custom_name", fn)
+        assert result == {
+            "name": "custom_name",
+            "args": {
+                "args": [],
+                "varargs": None,
+                "keywords": None,
+                "defaults": (),
+            },
+            "doc": None,
+            "module": fn.__module__,
+        }
+
+
+# ===========================================================================
+# getFunctionInfo
+# ===========================================================================
+
+
+class TestGetFunctionInfo:
+    @staticmethod
+    def _module(**funcs):
+        module = types.ModuleType("_test_module")
+        for name, fn in funcs.items():
+            setattr(module, name, fn)
+        return module
+
+    def test_empty_module(self):
+        assert getFunctionInfo(types.ModuleType("_empty")) == []
+
+    def test_returns_public_function_metadata(self):
+        def fn(x):
+            """Fn docstring."""
+
+        assert getFunctionInfo(self._module(fn=fn)) == [
+            {
+                "name": "fn",
+                "args": {
+                    "args": ["x"],
+                    "varargs": None,
+                    "keywords": None,
+                    "defaults": (),
+                },
+                "doc": "Fn docstring.",
+                "module": fn.__module__,
+            }
+        ]
+
+    def test_skips_private_functions(self):
+        def _private():
+            pass
+
+        assert getFunctionInfo(self._module(_private=_private)) == []
+
+    def test_only_public_returned_from_mixed_module(self):
+        def fn_a():
+            pass
+
+        def fn_b():
+            pass
+
+        def _fn_c():
+            pass
+
+        result = getFunctionInfo(self._module(fn_a=fn_a, fn_b=fn_b, _fn_c=_fn_c))
+        assert [r["name"] for r in result] == ["fn_a", "fn_b"]
+
+
+# ===========================================================================
+# getClassInfo
+# ===========================================================================
+
+
+class TestGetClassInfo:
+    @staticmethod
+    def _module_with_class(cls):
+        module = types.ModuleType("_test_class_module")
+        setattr(module, cls.__name__, cls)
+        return module
+
+    def test_class_without_explicit_init_excluded(self):
+        class NoInit:
+            """No init class."""
+
+            def method(self):
+                pass
+
+        assert getClassInfo(self._module_with_class(NoInit)) == []
+
+    def test_returns_class_metadata_for_public_methods(self):
+        result = getClassInfo(self._module_with_class(legacy_synapse_class))
+
+        assert result == [
+            {
+                "name": "legacy_synapse_class",
+                "constructorArgs": {
+                    "args": ["self", "x", "y"],
+                    "varargs": None,
+                    "keywords": None,
+                    "defaults": (0,),
+                },
+                "doc": "Legacy Synapse class.",
+                "methods": [
+                    {
+                        "name": "legacy_synapse_class",
+                        "doc": "Legacy Synapse class.",
+                        "args": {
+                            "args": ["self", "x", "y"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (0,),
+                        },
+                    },
+                    {
+                        "name": "public_method",
+                        "doc": "A public method.",
+                        "args": {
+                            "args": ["self", "a"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                        "is_static": False,
+                    },
+                    {
+                        "name": "static_method",
+                        "doc": "Static method.",
+                        "args": {
+                            "args": ["self", "c"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                        "is_static": True,
+                    },
+                ],
+            }
+        ]
+
+    def test_marks_static_methods_and_async_wrappers(self):
+        result = getClassInfo(self._module_with_class(synapse_model_class))
+
+        assert result == [
+            {
+                "name": "synapse_model_class",
+                "constructorArgs": {
+                    "args": ["self"],
+                    "varargs": None,
+                    "keywords": None,
+                    "defaults": (),
+                },
+                "doc": "Synapse model class.",
+                "methods": [
+                    {
+                        "name": "synapse_model_class",
+                        "doc": "Synapse model class.",
+                        "args": {
+                            "args": ["self"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                    },
+                    {
+                        "name": "get",
+                        "doc": "Async get function.",
+                        "args": {
+                            "args": ["self", "a"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                        "is_static": False,
+                    },
+                    {
+                        "name": "get_async",
+                        "doc": "Async get function.",
+                        "args": {
+                            "args": ["self", "a"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                        "is_static": False,
+                    },
+                    {
+                        "name": "static_method",
+                        "doc": "Static method.",
+                        "args": {
+                            "args": ["c", "d"],
+                            "varargs": None,
+                            "keywords": None,
+                            "defaults": (),
+                        },
+                        "is_static": True,
+                    },
+                ],
+            }
+        ]
+
+
+# ===========================================================================
+# is_async_to_sync_wrapper
+# ===========================================================================
+
+
+class TestIsAsyncToSyncWrapper:
+    def test_sync_with_async_sibling_is_wrapper(self):
+        assert is_async_to_sync_wrapper("get", synapse_model_class)
+
+    def test_regular_method_is_not_wrapper(self):
+        assert not is_async_to_sync_wrapper("get_async", synapse_model_class)
+
+    def test_nonexistent_method_returns_false(self):
+        assert not is_async_to_sync_wrapper("nonexistent", synapse_model_class)
+
+    def test_static_method_is_not_wrapper(self):
+        assert not is_async_to_sync_wrapper("static_method", synapse_model_class)
+
+
+# ===========================================================================
+# _is_static_in_mro
+# ===========================================================================
+
+
+class TestIsStaticInMro:
+    def test_staticmethod_returns_true(self):
+        assert _is_static_in_mro("static_method", synapse_model_class)
+
+    def test_instance_method_returns_false(self):
+        assert not _is_static_in_mro("get", synapse_model_class)
+
+    def test_nonexistent_method_returns_false(self):
+        assert not _is_static_in_mro("nonexistent", synapse_model_class)
+
+    def test_inherited_staticmethod_returns_true(self):
+        class _Base:
+            @staticmethod
+            def inherited_static(x):
+                return x
+
+        class _Derived(_Base):
+            def __init__(self):
+                pass
+
+            def own_method(self):
+                pass
+
+        assert _is_static_in_mro("inherited_static", _Derived)
+        assert not _is_static_in_mro("own_method", _Derived)
+
+
+# ===========================================================================
+# _get_static_method_func
+# ===========================================================================
+
+
+class TestGetStaticMethodFunc:
+    def test_returns_callable_for_staticmethod(self):
+        fn = _get_static_method_func("static_method", synapse_model_class)
+        assert callable(fn)
+
+    def test_returns_none_for_instance_method(self):
+        assert not _is_static_in_mro("get", synapse_model_class)
+
+    def test_inherited_staticmethod_resolved(self):
+        class _Base:
+            @staticmethod
+            def inherited_static(x):
+                return x
+
+        class _Derived(_Base):
+            def __init__(self):
+                pass
+
+            def own_method(self):
+                pass
+
+        fn = _get_static_method_func("inherited_static", _Derived)
+        assert callable(fn)
+        assert not _is_static_in_mro("own_method", _Derived)

--- a/tests/test_pyPkgInfo.py
+++ b/tests/test_pyPkgInfo.py
@@ -1,16 +1,12 @@
 """Unit tests for inst/python/pyPkgInfo.py"""
 
-import inspect
 import os
 import sys
 import types
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../inst/python"))
 
 from pyPkgInfo import (
-    _get_static_method_func,
     _is_static_in_mro,
     argspec_content,
     get_cleaned_doc,
@@ -58,6 +54,19 @@ class synapse_model_class:
         """Static method."""
         return c + d
 
+
+class synapse_model_class_with_static_async:
+    """Synapse model class with a @staticmethod async method (mirrors QueryMixin.query_async)."""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    async def query_async(query, limit=None):
+        """Async static query method."""
+
+    def query(self, query, limit=None):
+        """Sync wrapper for query_async."""
 
 # ===========================================================================
 # argspec_content
@@ -374,7 +383,6 @@ class TestGetClassInfo:
             }
         ]
 
-
 # ===========================================================================
 # is_async_to_sync_wrapper
 # ===========================================================================
@@ -393,6 +401,16 @@ class TestIsAsyncToSyncWrapper:
     def test_static_method_is_not_wrapper(self):
         assert not is_async_to_sync_wrapper("static_method", synapse_model_class)
 
+    def test_static_async_sibling_is_wrapper(self):
+        # query_async is declared @staticmethod async; is_async_to_sync_wrapper must
+        # unwrap the staticmethod descriptor before checking iscoroutinefunction.
+        assert is_async_to_sync_wrapper("query", synapse_model_class_with_static_async)
+
+    def test_static_async_method_itself_is_not_wrapper(self):
+        # query_async has no query_async_async sibling → not a wrapper
+        assert not is_async_to_sync_wrapper(
+            "query_async", synapse_model_class_with_static_async
+        )
 
 # ===========================================================================
 # _is_static_in_mro
@@ -426,32 +444,3 @@ class TestIsStaticInMro:
         assert not _is_static_in_mro("own_method", _Derived)
 
 
-# ===========================================================================
-# _get_static_method_func
-# ===========================================================================
-
-
-class TestGetStaticMethodFunc:
-    def test_returns_callable_for_staticmethod(self):
-        fn = _get_static_method_func("static_method", synapse_model_class)
-        assert callable(fn)
-
-    def test_returns_none_for_instance_method(self):
-        assert not _is_static_in_mro("get", synapse_model_class)
-
-    def test_inherited_staticmethod_resolved(self):
-        class _Base:
-            @staticmethod
-            def inherited_static(x):
-                return x
-
-        class _Derived(_Base):
-            def __init__(self):
-                pass
-
-            def own_method(self):
-                pass
-
-        fn = _get_static_method_func("inherited_static", _Derived)
-        assert callable(fn)
-        assert not _is_static_in_mro("own_method", _Derived)

--- a/tests/testthat/test_PythonPkgWrapperUtils.R
+++ b/tests/testthat/test_PythonPkgWrapperUtils.R
@@ -1,0 +1,1132 @@
+context("test PythonPkgWrapperUtils")
+
+# ---------------------------------------------------------------------------
+# capitalizeFirstLetter
+# ---------------------------------------------------------------------------
+
+test_that("capitalizeFirstLetter capitalizes single lowercase word", {
+  expect_equal("Hello", capitalizeFirstLetter("hello"))
+})
+
+test_that("capitalizeFirstLetter leaves already-capitalized word unchanged", {
+  expect_equal("Hello", capitalizeFirstLetter("Hello"))
+})
+
+test_that("capitalizeFirstLetter handles single character", {
+  expect_equal("A", capitalizeFirstLetter("a"))
+})
+
+test_that("capitalizeFirstLetter only changes the first character", {
+  expect_equal("HELLO", capitalizeFirstLetter("hELLO"))
+})
+
+# ---------------------------------------------------------------------------
+# snakeToCamel
+# ---------------------------------------------------------------------------
+
+test_that("snakeToCamel converts snake_case to CamelCase", {
+  expect_equal("FindEntityId", snakeToCamel("find_entity_id"))
+})
+
+test_that("snakeToCamel capitalizes a single word", {
+  expect_equal("Get", snakeToCamel("get"))
+})
+
+test_that("snakeToCamel handles two-part name", {
+  expect_equal("IsSynapseId", snakeToCamel("is_synapse_id"))
+})
+
+test_that("snakeToCamel handles three-part download_list_files style names", {
+  expect_equal("DownloadListFiles", snakeToCamel("download_list_files"))
+})
+
+# ---------------------------------------------------------------------------
+# addPrefix
+# ---------------------------------------------------------------------------
+
+test_that("addPrefix prepends prefix to camelCase name", {
+  expect_equal("synGet", addPrefix("get", "syn"))
+})
+
+test_that("addPrefix converts snake_case before prepending", {
+  expect_equal("synFindEntityId", addPrefix("find_entity_id", "syn"))
+})
+
+test_that("addPrefix works with three-part snake_case", {
+  expect_equal("synDownloadListFiles", addPrefix("download_list_files", "syn"))
+})
+
+# ---------------------------------------------------------------------------
+# removeNulls
+# ---------------------------------------------------------------------------
+
+test_that("removeNulls removes NULL elements from a list", {
+  expect_equal(list("a", "b", "c"), removeNulls(list("a", NULL, "b", NULL, "c")))
+})
+
+test_that("removeNulls returns list unchanged when no NULLs present", {
+  input <- list("a", "b", "c")
+  expect_equal(input, removeNulls(input))
+})
+
+test_that("removeNulls returns empty list when all elements are NULL", {
+  expect_equal(list(), removeNulls(list(NULL, NULL)))
+})
+
+# ---------------------------------------------------------------------------
+# determineArgsAndKwArgs
+# ---------------------------------------------------------------------------
+
+test_that("determineArgsAndKwArgs separates positional and keyword args", {
+  result <- determineArgsAndKwArgs("syn123", limit = 10L, includeTypes = "file")
+  expect_equal(list("syn123"), result$args)
+  expect_equal(list(limit = 10L, includeTypes = "file"), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs handles only positional args", {
+  result <- determineArgsAndKwArgs("a", "b", "c")
+  expect_equal(list("a", "b", "c"), result$args)
+  expect_equal(list(), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs handles only keyword args", {
+  result <- determineArgsAndKwArgs(entity = "syn123", downloadFile = TRUE)
+  expect_equal(list(), result$args)
+  expect_equal(list(entity = "syn123", downloadFile = TRUE), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs handles no args", {
+  result <- determineArgsAndKwArgs()
+  expect_equal(list(), result$args)
+  expect_equal(list(), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs handles NULL positional arg", {
+  result <- determineArgsAndKwArgs(NULL)
+  expect_equal(list(NULL), result$args)
+  expect_equal(list(), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs handles NULL keyword arg", {
+  result <- determineArgsAndKwArgs(entity = NULL)
+  expect_equal(list(), result$args)
+  expect_equal(list(entity = NULL), result$kwargs)
+})
+
+test_that("determineArgsAndKwArgs errors when positional follows keyword", {
+  expect_error(determineArgsAndKwArgs(a = "x", "y"))
+})
+
+test_that("determineArgsAndKwArgs last value wins on duplicate keyword argument", {
+  result <- determineArgsAndKwArgs(entity = "syn123", entity = "syn456")
+  expect_equal(list(entity = "syn456"), result$kwargs)
+})
+
+# ---------------------------------------------------------------------------
+# .createFormalArgs
+# ---------------------------------------------------------------------------
+
+test_that(".createFormalArgs returns empty list for no-param function", {
+  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  expect_length(.createFormalArgs(pyParams), 0)
+})
+
+test_that(".createFormalArgs creates required args with no defaults", {
+  pyParams <- list(
+    args = c("x", "y"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+
+  result <- .createFormalArgs(pyParams)
+
+  expect_named(result, c("x", "y"))
+  expect_identical(result$x, quote(expr =))
+  expect_identical(result$y, quote(expr =))
+})
+
+test_that(".createFormalArgs strips self from arg list", {
+  pyParams <- list(args = list("self", "x"), defaults = list(), varargs = NULL, keywords = NULL)
+  result <- .createFormalArgs(pyParams)
+  expect_true("x" %in% names(result))
+  expect_false("self" %in% names(result))
+})
+
+test_that(".createFormalArgs assigns defaults to trailing args", {
+  pyParams <- list(
+    args = c("x", "y", "z"),
+    defaults = list(10, "hello"),
+    varargs = NULL,
+    keywords = NULL
+  )
+
+  result <- .createFormalArgs(pyParams)
+
+  expect_named(result, c("x", "y", "z"))
+  expect_identical(result$x, quote(expr =))
+  expect_identical(result$y, 10)
+  expect_identical(result$z, "hello")
+})
+
+test_that(".createFormalArgs adds dots when varargs is present", {
+  pyParams <- list(
+    args = c("x"),
+    defaults = list(),
+    varargs = "args",
+    keywords = NULL
+  )
+
+  result <- .createFormalArgs(pyParams)
+
+  expect_named(result, c("x", "..."))
+  expect_identical(result$x, quote(expr =))
+  expect_identical(result$..., quote(expr =))
+})
+
+test_that(".createFormalArgs adds dots when keywords is present", {
+  pyParams <- list(
+    args = c("x"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = "kwargs"
+  )
+
+  result <- .createFormalArgs(pyParams)
+
+  expect_named(result, c("x", "..."))
+  expect_identical(result$x, quote(expr =))
+  expect_identical(result$..., quote(expr =))
+})
+
+test_that(".createFormalArgs handles no args but varargs present", {
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = "args",
+    keywords = NULL
+  )
+
+  result <- .createFormalArgs(pyParams)
+
+  expect_named(result, "...")
+  expect_identical(result$..., quote(expr =))
+})
+# ---------------------------------------------------------------------------
+# applyFunctionNameMapping
+# ---------------------------------------------------------------------------
+
+test_that("applyFunctionNameMapping returns default name when no mapping", {
+  expect_equal("synFindEntityId", applyFunctionNameMapping("synFindEntityId", NULL))
+})
+
+test_that("applyFunctionNameMapping applies explicit mapping", {
+  mapping <- list(explicit = list("synFromPathFile" = "synGetFileFromPath"))
+  expect_equal("synGetFileFromPath", applyFunctionNameMapping("synFromPathFile", mapping))
+})
+
+test_that("applyFunctionNameMapping returns default when name not in map", {
+  mapping <- list(explicit = list("synFromPathFile" = "synGetFileFromPath"))
+  expect_equal("synUnmapped", applyFunctionNameMapping("synUnmapped", mapping))
+})
+
+test_that("applyFunctionNameMapping applies all predefined synapseClient models mappings", {
+  mapping <- .synapseClientModelsMapping()
+  expect_equal("synDisassociateActivityFromEntity", applyFunctionNameMapping("synDisassociateFromEntity", mapping))
+  expect_equal("synGetFromPath",                    applyFunctionNameMapping("synFromPath",               mapping))
+  expect_equal("synInviteToTeam",                   applyFunctionNameMapping("synInvite",                 mapping))
+  expect_equal("synGetTeamMembers",                 applyFunctionNameMapping("synMembers",                mapping))
+  expect_equal("synGetOpenInvitations",             applyFunctionNameMapping("synOpenInvitations",        mapping))
+})
+
+# ---------------------------------------------------------------------------
+# .replaceAuthMessage
+# ---------------------------------------------------------------------------
+
+test_that(".replaceAuthMessage replaces Python auth error with R-friendly message", {
+  pythonMsg <- paste0(
+    "You have not provided valid credentials for Synapse.",
+    " Please provide your credentials for more information."
+  )
+  result <- .replaceAuthMessage(pythonMsg)
+  expect_true(grepl("synLogin()", result, fixed = TRUE))
+  expect_true(grepl("manageSynapseCredentials", result, fixed = TRUE))
+})
+
+test_that(".replaceAuthMessage leaves unrelated text unchanged", {
+  unrelated <- "Some other error occurred."
+  expect_equal(unrelated, .replaceAuthMessage(unrelated))
+})
+
+# ---------------------------------------------------------------------------
+# cleanUpStackTrace
+# ---------------------------------------------------------------------------
+
+test_that("cleanUpStackTrace returns the result of the callable", {
+  expect_equal(42L, cleanUpStackTrace(function() 42L, list()))
+})
+
+test_that("cleanUpStackTrace passes args to the callable", {
+  expect_equal(42L, cleanUpStackTrace(function(x, y) x + y, list(10L, 32L)))
+})
+
+test_that("cleanUpStackTrace propagates errors from the callable", {
+  expect_error(
+    cleanUpStackTrace(function() stop("expected test error"), list()),
+    "expected test error"
+  )
+})
+
+test_that("cleanUpStackTrace extracts message after boundary marker in non-verbose mode", {
+  old_verbose <- getOption("verbose")
+  on.exit(options(verbose = old_verbose))
+  options(verbose = FALSE)
+
+  callable <- function() stop("python traceback\nexception-message-boundary\nclean user message")
+  err <- tryCatch(
+    cleanUpStackTrace(callable, list()),
+    error = function(e) e$message
+  )
+  expect_true(grepl("clean user message", err))
+  expect_false(grepl("python traceback", err))
+})
+
+test_that("cleanUpStackTrace preserves full error when verbose is TRUE", {
+  old_verbose <- getOption("verbose")
+  on.exit(options(verbose = old_verbose))
+  options(verbose = TRUE)
+
+  callable <- function() stop("python traceback\nexception-message-boundary\nclean user message")
+  err <- tryCatch(
+    cleanUpStackTrace(callable, list()),
+    error = function(e) e$message
+  )
+  expect_true(grepl("python traceback", err))
+  expect_true(grepl("clean user message", err))
+})
+
+test_that("cleanUpStackTrace does not split error without a boundary marker", {
+  old_verbose <- getOption("verbose")
+  on.exit(options(verbose = old_verbose))
+  options(verbose = FALSE)
+
+  callable <- function() stop("just a plain error")
+  err <- tryCatch(
+    cleanUpStackTrace(callable, list()),
+    error = function(e) e$message
+  )
+  expect_true(grepl("just a plain error", err))
+})
+
+# ---------------------------------------------------------------------------
+# defineEnum / autoGenerateEnum
+# ---------------------------------------------------------------------------
+
+test_that("defineEnum calls callback with correct name, keys, and values", {
+  received <- list()
+  mockCallback <- function(name, keys, values) {
+    received <<- list(name = name, keys = keys, values = values)
+  }
+  defineEnum(mockCallback, "MyEnum", c("KEY1", "KEY2"), c(1L, 2L))
+  expect_equal("MyEnum", received$name)
+  expect_equal(c("KEY1", "KEY2"), received$keys)
+  expect_equal(c(1L, 2L), received$values)
+})
+
+test_that("autoGenerateEnum calls defineEnum for every entry in enumInfo", {
+  received <- list()
+  mockCallback <- function(name, keys, values) {
+    received[[name]] <<- list(keys = keys, values = values)
+  }
+  enumInfo <- list(
+    list(name = "Enum1", keys = c("A"),      values = c(1L)),
+    list(name = "Enum2", keys = c("X", "Y"), values = c(10L, 20L))
+  )
+  autoGenerateEnum(mockCallback, enumInfo)
+  expect_true("Enum1" %in% names(received))
+  expect_true("Enum2" %in% names(received))
+  expect_equal(c("X", "Y"), received$Enum2$keys)
+  expect_equal(c(10L, 20L), received$Enum2$values)
+})
+
+test_that("autoGenerateEnum is a no-op for empty enumInfo", {
+  called <- FALSE
+  mockCallback <- function(name, keys, values) { called <<- TRUE }
+  autoGenerateEnum(mockCallback, list())
+  expect_false(called)
+})
+
+# ---------------------------------------------------------------------------
+# getDescription
+# ---------------------------------------------------------------------------
+
+test_that("getDescription returns empty string for NULL", {
+  expect_equal("", getDescription(NULL))
+})
+
+test_that("getDescription returns empty string for empty string", {
+  expect_equal("", getDescription(""))
+})
+
+test_that("getDescription returns full text when no Sphinx tokens", {
+  doc <- "This is a plain description."
+  expect_equal(doc, getDescription(doc))
+})
+
+test_that("getDescription stops before :param: marker", {
+  doc <- "Summary line.\n:param name: the name"
+  expect_equal("Summary line.", getDescription(doc))
+})
+
+test_that("getDescription stops before :returns: marker", {
+  doc <- "Summary line.\n:returns: the result"
+  expect_equal("Summary line.", getDescription(doc))
+})
+
+test_that("getDescription stops before :return: (no s) marker", {
+  doc <- "Summary line.\n:return: the result"
+  expect_equal("Summary line.", getDescription(doc))
+})
+
+test_that("getDescription stops before :type: marker", {
+  doc <- "Summary line.\n:type name: str"
+  expect_equal("Summary line.", getDescription(doc))
+})
+
+test_that("getDescription normalises CRLF to LF", {
+  doc <- "Summary line.\r\n:param x: foo"
+  expect_equal("Summary line.", getDescription(doc))
+})
+
+# ---------------------------------------------------------------------------
+# getReturned
+# ---------------------------------------------------------------------------
+
+test_that("getReturned returns empty string for NULL", {
+  expect_equal("", getReturned(NULL))
+})
+
+test_that("getReturned returns empty string for empty string", {
+  expect_equal("", getReturned(""))
+})
+
+test_that("getReturned returns empty string when no :returns: section", {
+  expect_equal("", getReturned("A description with no return section."))
+})
+
+test_that("getReturned extracts :returns: description", {
+  doc <- "A function.\n:returns: the result value"
+  expect_true(grepl("the result value", getReturned(doc)))
+})
+
+test_that("getReturned works with :return: (no s)", {
+  doc <- "A function.\n:return: the result value"
+  expect_true(grepl("the result value", getReturned(doc)))
+})
+
+test_that("getReturned stops at a double newline", {
+  doc <- "A function.\n:returns: the result\n\nExtra text that should be cut"
+  result <- getReturned(doc)
+  expect_false(grepl("Extra text", result))
+  expect_true(grepl("the result", result))
+})
+
+# ---------------------------------------------------------------------------
+# getExample
+# ---------------------------------------------------------------------------
+
+test_that("getExample returns empty string for NULL", {
+  expect_equal("", getExample(NULL))
+})
+
+test_that("getExample returns empty string for empty string", {
+  expect_equal("", getExample(""))
+})
+
+test_that("getExample returns empty string when no example section", {
+  expect_equal("", getExample("A plain description."))
+})
+
+test_that("getExample extracts content after Example::", {
+  doc <- "Example::\n\n  result = do_thing()"
+  result <- getExample(doc)
+  expect_true(grepl("do_thing", result))
+})
+
+test_that("getExample matches lowercase example::", {
+  doc <- "example::\n\n  code_here()"
+  result <- getExample(doc)
+  expect_true(grepl("code_here", result))
+})
+
+test_that("getExample matches Example: (single colon)", {
+  doc <- "Example:\n\n  code_here()"
+  result <- getExample(doc)
+  expect_true(grepl("code_here", result))
+})
+
+# ---------------------------------------------------------------------------
+# changeSphinxHyperlinksToLatex / convertSphinxToLatex
+# ---------------------------------------------------------------------------
+
+test_that("changeSphinxHyperlinksToLatex converts Sphinx links to \\href", {
+  raw    <- "`link text <http://example.com>`_"
+  result <- changeSphinxHyperlinksToLatex(raw)
+  expect_true(grepl("\\\\href\\{http://example\\.com\\}\\{link text\\}", result))
+})
+
+test_that("changeSphinxHyperlinksToLatex leaves plain text unchanged", {
+  raw <- "No hyperlinks here."
+  expect_equal(raw, changeSphinxHyperlinksToLatex(raw))
+})
+
+test_that("convertSphinxToLatex delegates to changeSphinxHyperlinksToLatex", {
+  raw    <- "`text <http://example.com>`_"
+  expect_equal(changeSphinxHyperlinksToLatex(raw), convertSphinxToLatex(raw))
+})
+
+# ---------------------------------------------------------------------------
+# insertLatexNewLines
+# ---------------------------------------------------------------------------
+
+test_that("insertLatexNewLines replaces newlines with \\cr newlines", {
+  raw    <- "line1\nline2"
+  result <- insertLatexNewLines(raw)
+  expect_equal("line1\\cr\nline2", result)
+})
+
+test_that("insertLatexNewLines leaves string without newlines unchanged", {
+  raw <- "no newlines here"
+  expect_equal(raw, insertLatexNewLines(raw))
+})
+
+test_that("insertLatexNewLines handles multiple newlines", {
+  raw    <- "a\nb\nc"
+  result <- insertLatexNewLines(raw)
+  expect_equal("a\\cr\nb\\cr\nc", result)
+})
+
+# ---------------------------------------------------------------------------
+# pyVerbiageToLatex
+# ---------------------------------------------------------------------------
+
+test_that("pyVerbiageToLatex returns empty string for NULL", {
+  expect_equal("", pyVerbiageToLatex(NULL))
+})
+
+test_that("pyVerbiageToLatex returns empty string for empty string", {
+  expect_equal("", pyVerbiageToLatex(""))
+})
+
+test_that("pyVerbiageToLatex strips :py:class: and keeps only the final component", {
+  result <- pyVerbiageToLatex("See :py:class:`synapseclient.entity.File`.")
+  expect_false(grepl(":py:class:", result))
+  expect_false(grepl("synapseclient.entity", result))
+  expect_true(grepl("File", result))
+})
+
+test_that("pyVerbiageToLatex capitalizes the first letter of the final component of :py:mod:", {
+  result <- pyVerbiageToLatex("Use :py:mod:`synapseclient.table`.")
+  expect_false(grepl(":py:mod:", result))
+  expect_true(grepl("Table", result))
+})
+
+test_that("pyVerbiageToLatex strips :py:func: and :py:meth: tags, keeping the text", {
+  result_func <- pyVerbiageToLatex("Call :py:func:`synapseclient.login`.")
+  expect_false(grepl(":py:func:", result_func))
+  expect_true(grepl("synapseclient.login", result_func))
+
+  result_meth <- pyVerbiageToLatex("Call :py:meth:`Synapse.login`.")
+  expect_false(grepl(":py:meth:", result_meth))
+  expect_true(grepl("Synapse.login", result_meth))
+})
+
+test_that("pyVerbiageToLatex converts Sphinx hyperlinks in text", {
+  result <- pyVerbiageToLatex("`Synapse <http://synapse.org>`_")
+  expect_true(grepl("\\\\href", result))
+})
+
+test_that("pyVerbiageToLatex converts :param: tags to plain text form", {
+  result <- pyVerbiageToLatex(":param entity: the entity to get")
+  expect_false(grepl(":param", result))
+  expect_true(grepl("entity:", result))
+})
+
+# ---------------------------------------------------------------------------
+# formatArgsForArgumentSection
+# ---------------------------------------------------------------------------
+
+test_that("formatArgsForArgumentSection returns empty string for no args", {
+  expect_equal("", formatArgsForArgumentSection(list(), list()))
+})
+
+test_that("formatArgsForArgumentSection produces \\item entries for each arg", {
+  argNames <- list("entity", "version")
+  argDesc  <- list(entity = "The entity", version = "Version number")
+  result   <- formatArgsForArgumentSection(argNames, argDesc)
+  expect_true(grepl("\\\\item\\{entity\\}", result))
+  expect_true(grepl("\\\\item\\{version\\}", result))
+})
+
+test_that("formatArgsForArgumentSection uses empty description when arg not in docstring", {
+  argNames <- list("entity")
+  result   <- formatArgsForArgumentSection(argNames, list())
+  expect_true(grepl("\\\\item\\{entity\\}\\{\\}", result))
+})
+
+test_that("formatArgsForArgumentSection skips self as first arg", {
+  argNames <- list("self", "entity")
+  result   <- formatArgsForArgumentSection(argNames, list())
+  expect_false(grepl("\\{self\\}", result))
+  expect_true(grepl("\\{entity\\}", result))
+})
+
+test_that("formatArgsForArgumentSection marks extra docstring args as optional named parameters", {
+  argNames <- list("entity")
+  argDesc  <- list(entity = "The entity", extraArg = "An optional kwarg")
+  result   <- formatArgsForArgumentSection(argNames, argDesc)
+  expect_true(grepl("optional named parameter", result))
+  expect_true(grepl("extraArg", result))
+})
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+
+test_that("usage produces empty-parens string for no-arg function", {
+  args <- list(args = list(), defaults = list())
+  expect_equal("myFunc()", usage("myFunc", args, list()))
+})
+
+test_that("usage lists all args with no defaults", {
+  args <- list(args = list("entity", "version"), defaults = list())
+  expect_equal("myFunc(entity, version)", usage("myFunc", args, list()))
+})
+
+test_that("usage appends =value for defaulted args", {
+  args <- list(args = list("entity", "version", "followLink"), defaults = list(NULL, FALSE))
+  result <- usage("myFunc", args, list())
+  expect_true(grepl("version=NULL", result))
+  expect_true(grepl("followLink=FALSE", result))
+})
+
+test_that("usage skips self as first arg", {
+  args <- list(args = list("self", "entity"), defaults = list())
+  expect_equal("myMethod(entity)", usage("myMethod", args, list()))
+})
+
+test_that("usage skips typ as first arg", {
+  args <- list(args = list("typ", "entity"), defaults = list())
+  expect_equal("myMethod(entity)", usage("myMethod", args, list()))
+})
+
+test_that("usage appends extra docstring kwargs as arg=NULL", {
+  args    <- list(args = list("entity"), defaults = list())
+  argDesc <- list(entity = "the entity", extraParam = "a kwarg")
+  result  <- usage("myFunc", args, argDesc)
+  expect_true(grepl("extraParam=NULL", result))
+})
+
+# ---------------------------------------------------------------------------
+# parseArgDescriptionsFromDetails
+# ---------------------------------------------------------------------------
+
+test_that("parseArgDescriptionsFromDetails returns empty list for plain description", {
+  result <- parseArgDescriptionsFromDetails("Just a description, no params.")
+  expect_equal(0L, length(result))
+})
+
+test_that("parseArgDescriptionsFromDetails extracts single :param: description", {
+  doc    <- "A function.\n:param name: the entity name"
+  result <- parseArgDescriptionsFromDetails(doc)
+  expect_true("name" %in% names(result))
+  expect_true(grepl("entity name", result$name))
+})
+
+test_that("parseArgDescriptionsFromDetails extracts multiple :param: descriptions", {
+  doc    <- ":param entity: the synapse entity\n:param version: the version number"
+  result <- parseArgDescriptionsFromDetails(doc)
+  expect_true("entity"  %in% names(result))
+  expect_true("version" %in% names(result))
+})
+
+test_that("parseArgDescriptionsFromDetails truncates description at double newline", {
+  doc    <- ":param name: the name\n\nExtra text that should be excluded"
+  result <- parseArgDescriptionsFromDetails(doc)
+  expect_false(grepl("Extra text", result$name))
+})
+
+test_that("parseArgDescriptionsFromDetails accepts :parameter: keyword as well", {
+  doc    <- ":parameter entity: the synapse entity"
+  result <- parseArgDescriptionsFromDetails(doc)
+  expect_true("entity" %in% names(result))
+})
+
+# ---------------------------------------------------------------------------
+# generateFunctionalInterfaceInfo
+# ---------------------------------------------------------------------------
+
+test_that("generateFunctionalInterfaceInfo returns empty list for class with no methods", {
+  classInfo <- list(list(name = "MyClass", methods = NULL, constructorArgs = list(), doc = ""))
+  expect_equal(list(), generateFunctionalInterfaceInfo(classInfo))
+})
+
+test_that("generateFunctionalInterfaceInfo skips the constructor method", {
+  classInfo <- list(list(
+    name    = "MyClass",
+    methods = list(list(
+      name = "MyClass", doc = "",
+      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+    )),
+    constructorArgs = list(), doc = ""
+  ))
+  expect_equal(list(), generateFunctionalInterfaceInfo(classInfo))
+})
+
+test_that("generateFunctionalInterfaceInfo creates correct generic name with syn prefix", {
+  classInfo <- list(list(
+    name    = "File",
+    methods = list(list(
+      name = "get", doc = "",
+      args = list(args = list("self", "synapse_id"), defaults = list(), varargs = NULL, keywords = NULL)
+    )),
+    constructorArgs = list(), doc = ""
+  ))
+  result <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
+  expect_equal(1L,       length(result))
+  expect_equal("synGet", result[[1]]$rName)
+  expect_equal("File",   result[[1]]$targetClass)
+  expect_true("synapse_id" %in% result[[1]]$args$args)
+})
+
+test_that("generateFunctionalInterfaceInfo strips self and does not add instance", {
+  classInfo <- list(list(
+    name    = "File",
+    methods = list(list(
+      name = "store", doc = "",
+      args = list(args = list("self", "force"), defaults = list(), varargs = NULL, keywords = NULL)
+    )),
+    constructorArgs = list(), doc = ""
+  ))
+  result <- generateFunctionalInterfaceInfo(classInfo)
+  args   <- result[[1]]$args$args
+  expect_false("self"     %in% args)
+  expect_false("instance" %in% args)
+  expect_true("force"     %in% args)
+})
+
+test_that("generateFunctionalInterfaceInfo applies function name mapping", {
+  classInfo <- list(list(
+    name    = "Team",
+    methods = list(list(
+      name = "invite", doc = "",
+      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+    )),
+    constructorArgs = list(), doc = ""
+  ))
+  mapping <- list(explicit = list("synInvite" = "synInviteToTeam"))
+  result  <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn",
+                                             functionNameMapping = mapping)
+  expect_equal("synInviteToTeam", result[[1]]$rName)
+})
+
+test_that("generateFunctionalInterfaceInfo sets functionContainerName to ClassName.methodName", {
+  classInfo <- list(list(
+    name    = "File",
+    methods = list(list(
+      name = "get_acl", doc = "",
+      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+    )),
+    constructorArgs = list(), doc = ""
+  ))
+  result <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
+  expect_equal("File.get_acl", result[[1]]$functionContainerName)
+})
+
+test_that("generateFunctionalInterfaceInfo iterates all classes and all methods", {
+  classInfo <- list(
+    list(
+      name    = "File",
+      methods = list(
+        list(name = "get_acl", doc = "",
+             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)),
+        list(name = "snapshot", doc = "",
+             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL))
+      ),
+      constructorArgs = list(), doc = ""
+    ),
+    list(
+      name    = "Project",
+      methods = list(
+        list(name = "delete", doc = "",
+             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL))
+      ),
+      constructorArgs = list(), doc = ""
+    )
+  )
+  result        <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
+  rNames        <- sapply(result, function(x) x$rName)
+  targetClasses <- sapply(result, function(x) x$targetClass)
+
+  expect_equal(3L, length(result))
+  expect_true("synGetAcl"   %in% rNames)
+  expect_true("synSnapshot" %in% rNames)
+  expect_true("synDelete"   %in% rNames)
+  expect_equal(2L, sum(targetClasses == "File"))
+  expect_equal(1L, sum(targetClasses == "Project"))
+})
+
+# ---------------------------------------------------------------------------
+# defineConstructor (requires Python / gateway module)
+# ---------------------------------------------------------------------------
+
+test_that("defineConstructor calls setGenericCallback with the class name", {
+  # stand-in for setGeneric; records registered functions by name
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  defineConstructor("synapseclient.models", mockCb, "File", pyParams)
+
+  expect_true("File" %in% names(captured))
+})
+
+test_that("defineConstructor registers a no-arg constructor with empty formals", {
+  # stand-in for setGeneric; records registered functions by name
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  defineConstructor("synapseclient.models", mockCb, "Project", pyParams)
+
+  expect_length(formals(captured[["Project"]]), 1) # the ... in rFn
+})
+
+test_that("defineConstructor registers correct formals from pyParams args and defaults", {
+  # stand-in for setGeneric; records registered functions by name
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }  
+
+  pyParams <- list(
+    args     = list("name", "parent", "description"),
+    defaults = list("text"),
+    varargs  = NULL,
+    keywords = NULL
+  )
+  defineConstructor("synapseclient.models", mockCb, "Folder", pyParams)
+
+  fn_formals <- formals(captured[["Folder"]])
+  expect_named(fn_formals, c("name", "parent", "description"))
+  expect_identical(fn_formals$name,        quote(expr =))
+  expect_identical(fn_formals$parent,      quote(expr =))
+  expect_identical(fn_formals$description, "text")
+})
+
+test_that("defineConstructor adds dots when pyParams has keywords", {
+  # stand-in for setGeneric; records registered functions by name
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(
+    args     = list("name"),
+    defaults = list(),
+    varargs  = NULL,
+    keywords = "kwargs"
+  )
+  defineConstructor("synapseclient.models", mockCb, "Table", pyParams)
+
+  expect_true("..." %in% names(formals(captured[["Table"]])))
+})
+
+test_that("defineConstructor registered function prepends class name to returned object's class vector", {
+  # Mock gateway$invoke so no real Python constructor is called
+  # unlockBinding is needed because a prior test may have called .getGateway()
+  ns               <- environment(defineConstructor)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  # Ensure "sys" is in the Python namespace so py_eval("sys") succeeds
+  reticulate::py_run_string("import sys")
+
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  defineConstructor("sys", mockCb, "File", pyParams)
+
+  result <- captured[["File"]]()
+
+  expect_equal("File", class(result)[1])
+})
+
+# ---------------------------------------------------------------------------
+# defineClassMethod (requires Python / gateway module)
+# ---------------------------------------------------------------------------
+
+test_that("defineClassMethod registers function as ClassName_methodName", {
+  ns <- environment(defineClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+  # stand-in for setGeneric; records registered functions by name
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
+
+  expect_true("File_get" %in% names(captured))
+})
+
+test_that("defineClassMethod puts instance as first formal and drops self", {
+  ns <- environment(defineClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(
+    args     = list("self", "entity", "version"),
+    defaults = list(NULL),
+    varargs  = NULL,
+    keywords = NULL
+  )
+  defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
+
+  fn_formals <- names(formals(captured[["File_get"]]))
+  expect_equal("instance", fn_formals[1])
+  expect_false("self"    %in% fn_formals)
+  expect_true("entity"   %in% fn_formals)
+  expect_true("version"  %in% fn_formals)
+})
+
+test_that("defineClassMethod adds dots when pyParams has keywords", {
+  ns <- environment(defineClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = "kwargs")
+  defineClassMethod("synapseclient.models", mockCb, "File", "store", pyParams)
+
+  expect_true("..." %in% names(formals(captured[["File_store"]])))
+})
+
+test_that("defineClassMethod R function name comes from methodName, not pythonMethodName", {
+  ns <- environment(defineClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineClassMethod("synapseclient.models", mockCb, "File", "store", pyParams,
+                    pythonMethodName = "store_async")
+
+  expect_true("File_store" %in% names(captured))
+})
+
+test_that("defineClassMethod calling wrapper with NULL instance errors with class name", {
+  ns <- environment(defineClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb   <- function(name, def) { captured[[name]] <<- def }
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
+
+  expect_error(captured[["File_get"]](NULL), regexp = "File")
+})
+
+# ---------------------------------------------------------------------------
+# defineFunctionalClassMethod (requires Python / gateway module)
+# ---------------------------------------------------------------------------
+
+test_that("defineFunctionalClassMethod registers a generic name for the method", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineFunctionalClassMethod("synapseclient.models", "Project", "store", pyParams)
+
+  expect_true(exists("synStore", mode = "function", inherits = TRUE))
+  expect_false(exists("synStoreProject", mode = "function", inherits = TRUE))
+})
+
+test_that("defineFunctionalClassMethod stores inner worker in dispatch table", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineFunctionalClassMethod("synapseclient.models", "File", "store", pyParams)
+
+  expect_true(exists("synStore_File", envir = .functionalMethodDispatch, inherits = FALSE))
+
+  worker <- get("synStore_File", envir = .functionalMethodDispatch, inherits = FALSE)
+  expect_true(is.function(worker))
+  expect_equal("instance", names(formals(worker))[1])
+
+  fake_instance <- structure(list(), class = "File") # pass a fake instance to the worker
+  expect_equal(list(), worker(fake_instance))
+})
+
+test_that("defineFunctionalClassMethod generic errors with pipe-hint when called without instance", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  # Use get_acl — not a real registered function — so defineFunctionalClassMethod
+  # registers a fresh generic rather than skipping due to the !exists() guard.
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineFunctionalClassMethod("synapseclient.models", "Project", "get_acl", pyParams)
+
+  fn <- get("synGetAcl")
+  expect_error(fn(), regexp = "Pass an object as the first argument, e.g. ClassName\\(...\\) \\|> synGetAcl\\(\\)")
+})
+
+test_that("defineFunctionalClassMethod generic errors for unregistered class", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineFunctionalClassMethod("synapseclient.models", "Project", "get_acl", pyParams)
+
+  fn  <- get("synGetAcl")
+  obj <- structure(list(), class = "UnknownClass")
+  expect_error(fn(obj), regexp = "No 'synGetAcl' method registered for class 'UnknownClass'")
+})
+
+test_that("defineFunctionalClassMethod applies functionNameMapping to generic name", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  mapping  <- list(explicit = list("synInvite" = "synInviteToTeam"))
+  defineFunctionalClassMethod("synapseclient.models", "Team", "invite", pyParams,
+                              functionNameMapping = mapping)
+
+  expect_true(exists("synInviteToTeam", mode = "function", inherits = TRUE))
+  expect_false(exists("synInviteTeam",  mode = "function", inherits = TRUE))
+  expect_true(exists("synInviteToTeam_Team", envir = .functionalMethodDispatch, inherits = FALSE))
+})
+
+test_that("defineFunctionalClassMethod static: registers plain function without instance formal", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  localNs <- new.env(parent = ns)
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(args = list("query"), defaults = list(), varargs = NULL, keywords = NULL)
+  localDefineFunctionalClassMethod("synapseclient.models", "Table", "query", pyParams, isStatic = TRUE)
+
+  expect_true(exists("synQuery", envir = localNs, mode = "function", inherits = FALSE))
+  expect_false("instance" %in% names(formals(get("synQuery", envir = localNs))))
+  expect_true("query" %in% names(formals(get("synQuery", envir = localNs))))
+})
+
+# ---------------------------------------------------------------------------
+# defineFunction (requires Python / gateway module)
+# ---------------------------------------------------------------------------
+
+test_that("defineFunction registers function under the given R name", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) { captured[[name]] <<- def }
+  pyParams <- list(args = list("synapse_id"), defaults = list(), varargs = NULL, keywords = NULL)
+  defineFunction("synGet", "get", "synapseclient.operations", pyParams, mockCb)
+
+  expect_true("synGet" %in% names(captured))
+  expect_true(is.function(captured[["synGet"]]))
+})
+
+test_that("defineFunction creates formals matching pyParams args", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) { captured[[name]] <<- def }
+  pyParams <- list(
+    args     = list("entity", "version", "downloadFile"),
+    defaults = list(NULL, TRUE),
+    varargs  = NULL,
+    keywords = NULL
+  )
+  defineFunction("synGet", "get", "synapseclient.operations", pyParams, mockCb)
+
+  fn_formals <- formals(captured[["synGet"]])
+  expect_equal(c("entity", "version", "downloadFile"), names(fn_formals))
+  expect_identical(fn_formals$version,      NULL)
+  expect_identical(fn_formals$downloadFile, TRUE)
+})
+
+test_that("defineFunction adds dots and preserves args when pyParams has varargs", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) { captured[[name]] <<- def }
+
+  defineFunction("synStore", "store", "synapseclient.operations",
+                 list(args = list("entity"), defaults = list(), varargs = "args", keywords = NULL),
+                 mockCb)
+  varargs_formals <- names(formals(captured[["synStore"]]))
+  expect_true("entity" %in% varargs_formals)
+  expect_true("..." %in% varargs_formals)
+})
+
+test_that("defineFunction synStore has entity as first formal for pipe compatibility", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) { captured[[name]] <<- def }
+  pyParams <- list(args = list("entity"), defaults = list(), varargs = NULL, keywords = "kwargs")
+  defineFunction("synStore", "store", "synapseclient.operations", pyParams, mockCb)
+
+  expect_equal("entity", names(formals(captured[["synStore"]]))[1])
+})

--- a/tests/testthat/test_PythonPkgWrapperUtils.R
+++ b/tests/testthat/test_PythonPkgWrapperUtils.R
@@ -292,6 +292,19 @@ test_that(".replaceAuthMessage leaves unrelated text unchanged", {
   expect_equal(unrelated, .replaceAuthMessage(unrelated))
 })
 
+test_that(".replaceAuthMessage replaces multi-line Python auth error with R-friendly message", {
+  # (?s) dotall flag is required so .* matches across embedded newlines in the
+  # real Python auth exception text.
+  pythonMsg <- paste0(
+    "You have not provided valid credentials for Synapse.\n",
+    "Visit https://synapse.org to create a personal access token.\n",
+    "Please provide your credentials for more information."
+  )
+  result <- .replaceAuthMessage(pythonMsg)
+  expect_true(grepl("synLogin()", result, fixed = TRUE))
+  expect_false(grepl("Visit https://synapse.org", result, fixed = TRUE))
+})
+
 # ---------------------------------------------------------------------------
 # cleanUpStackTrace
 # ---------------------------------------------------------------------------
@@ -1293,7 +1306,7 @@ test_that("defineFunctionalClassMethod applies functionNameMapping to generic na
     varargs = NULL,
     keywords = NULL
   )
-  mapping <- list(explicit = list("synInvite" = "synInviteToTeam"))
+  mapping <- list(explicit = list("synInvite" = "synInviteToTeam_test"))
   localDefineFunctionalClassMethod(
     "synapseclient.models",
     "Team",
@@ -1303,7 +1316,7 @@ test_that("defineFunctionalClassMethod applies functionNameMapping to generic na
   )
 
   expect_true(exists(
-    "synInviteToTeam",
+    "synInviteToTeam_test",
     envir = localNs,
     mode = "function",
     inherits = FALSE
@@ -1356,6 +1369,113 @@ test_that("defineFunctionalClassMethod static: registers plain function without 
   ))
   expect_false("instance" %in% names(formals(get("synQuery", envir = localNs))))
   expect_true("query" %in% names(formals(get("synQuery", envir = localNs))))
+})
+
+test_that("defineFunctionalClassMethod static: forwards named formals to kwargs", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  reticulate::py_run_string("import builtins")
+
+  localNs <- new.env(parent = ns)
+  localNs$cleanUpStackTrace <- function(callable, args) args
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("query", "timeout"),
+    defaults = list(250L),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "builtins",
+    "dict",
+    "query",
+    pyParams,
+    isStatic = TRUE
+  )
+
+  result <- get("synQuery", envir = localNs)(
+    query = "select * from syn123 limit 2",
+    timeout = 42L
+  )
+  expect_equal(result$kwargs$query, "select * from syn123 limit 2")
+  expect_equal(result$kwargs$timeout, 42L)
+})
+
+test_that("defineFunctionalClassMethod static: forwards positional arg to args (not kwargs)", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  reticulate::py_run_string("import builtins")
+
+  localNs <- new.env(parent = ns)
+  localNs$cleanUpStackTrace <- function(callable, args) args
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("query", "timeout"),
+    defaults = list(250L),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "builtins",
+    "dict",
+    "query",
+    pyParams,
+    isStatic = TRUE
+  )
+
+  result <- get("synQuery", envir = localNs)("select * from syn123")
+  expect_equal(result$args[[1]], "select * from syn123")
+  expect_equal(length(result$kwargs), 0L)
+})
+
+test_that("defineFunctionalClassMethod static: does not register in functional dispatch table", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  localNs <- new.env(parent = ns)
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("query"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "synapseclient.models",
+    "Table",
+    "query",
+    pyParams,
+    isStatic = TRUE
+  )
+
+  expect_false(exists(
+    "synQuery_Table",
+    envir = .functionalMethodDispatch,
+    inherits = FALSE
+  ))
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test_PythonPkgWrapperUtils.R
+++ b/tests/testthat/test_PythonPkgWrapperUtils.R
@@ -1,3 +1,5 @@
+# One way to run the test is using devtools::test(filter = "PythonPkgWrapperUtils")
+# from the synapser package directory.
 context("test PythonPkgWrapperUtils")
 
 # ---------------------------------------------------------------------------
@@ -249,8 +251,28 @@ test_that("applyFunctionNameMapping returns default when name not in map", {
   expect_equal("synUnmapped", applyFunctionNameMapping("synUnmapped", mapping))
 })
 
-test_that("applyFunctionNameMapping applies all predefined synapseClient models mappings", {
-  mapping <- .synapseClientModelsMapping()
+test_that("applyFunctionNameMapping applies all predefined Synapse class mappings", {
+  mapping <- .functionNameMappingSynapse()
+  expect_equal(
+    "synRestGet",
+    applyFunctionNameMapping("synRestGetAsync", mapping)
+  )
+  expect_equal(
+    "synRestPut",
+    applyFunctionNameMapping("synRestPutAsync", mapping)
+  )
+  expect_equal(
+    "synRestPost",
+    applyFunctionNameMapping("synRestPostAsync", mapping)
+  )
+  expect_equal(
+    "synRestDelete",
+    applyFunctionNameMapping("synRestDeleteAsync", mapping)
+  )
+})
+
+test_that("applyFunctionNameMapping applies all predefined synapseclient.models mappings", {
+  mapping <- .functionNameMappingSynapseclientModels()
   expect_equal(
     "synDisassociateActivityFromEntity",
     applyFunctionNameMapping("synDisassociateFromEntity", mapping)
@@ -272,6 +294,7 @@ test_that("applyFunctionNameMapping applies all predefined synapseClient models 
     applyFunctionNameMapping("synOpenInvitations", mapping)
   )
 })
+
 
 # ---------------------------------------------------------------------------
 # .replaceAuthMessage
@@ -1581,4 +1604,193 @@ test_that("defineFunction synStore has entity as first formal for pipe compatibi
   )
 
   expect_equal("entity", names(formals(captured[["synStore"]]))[1])
+})
+
+test_that("defineFunction applies functionNameMapping to registered R name", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  mapping <- list(explicit = list("synRestGetAsync" = "synRestGet"))
+
+  defineFunction(
+    "synRestGetAsync",
+    "rest_get_async",
+    "synapseclient.Synapse",
+    pyParams,
+    mockCb,
+    functionNameMapping = mapping
+  )
+
+  expect_true("synRestGet" %in% names(captured))
+  expect_false("synRestGetAsync" %in% names(captured))
+})
+
+test_that("defineFunction falls back to original name when not in functionNameMapping", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  mapping <- list(explicit = list("synFoo" = "synBar"))
+
+  defineFunction(
+    "synGet",
+    "get",
+    "synapseclient.operations",
+    pyParams,
+    mockCb,
+    functionNameMapping = mapping
+  )
+
+  expect_true("synGet" %in% names(captured))
+  expect_false("synBar" %in% names(captured))
+})
+
+test_that("defineFunction with NULL functionNameMapping uses original name", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+
+  defineFunction(
+    "synRestGetAsync",
+    "rest_get_async",
+    "synapseclient.Synapse",
+    pyParams,
+    mockCb,
+    functionNameMapping = NULL
+  )
+
+  expect_true("synRestGetAsync" %in% names(captured))
+})
+
+# ---------------------------------------------------------------------------
+# autoGenerateFunctions
+# ---------------------------------------------------------------------------
+
+test_that("autoGenerateFunctions registers all functions by rName", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  functionInfo <- list(
+    list(
+      rName = "synGet",
+      pyName = "get",
+      functionContainerName = "synapseclient.operations",
+      args = pyParams
+    ),
+    list(
+      rName = "synStore",
+      pyName = "store",
+      functionContainerName = "synapseclient.operations",
+      args = pyParams
+    )
+  )
+
+  autoGenerateFunctions(mockCb, functionInfo)
+
+  expect_true("synGet" %in% names(captured))
+  expect_true("synStore" %in% names(captured))
+})
+
+test_that("autoGenerateFunctions applies functionNameMapping to matching entries", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  functionInfo <- list(
+    list(
+      rName = "synRestGetAsync",
+      pyName = "rest_get_async",
+      functionContainerName = "synapseclient.Synapse",
+      args = pyParams
+    ),
+    list(
+      rName = "synGet",
+      pyName = "get",
+      functionContainerName = "synapseclient.operations",
+      args = pyParams
+    )
+  )
+  mapping <- list(explicit = list("synRestGetAsync" = "synRestGet"))
+
+  autoGenerateFunctions(mockCb, functionInfo, functionNameMapping = mapping)
+
+  expect_true("synRestGet" %in% names(captured))
+  expect_false("synRestGetAsync" %in% names(captured))
+  expect_true("synGet" %in% names(captured))
+})
+
+test_that("autoGenerateFunctions with NULL functionNameMapping uses original rNames", {
+  ns <- environment(defineFunction)
+  original_gateway <- get(".gateway", envir = ns)
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  captured <- list()
+  mockCb <- function(name, def) captured[[name]] <<- def
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  functionInfo <- list(
+    list(
+      rName = "synRestGetAsync",
+      pyName = "rest_get_async",
+      functionContainerName = "synapseclient.Synapse",
+      args = pyParams
+    )
+  )
+
+  autoGenerateFunctions(mockCb, functionInfo, functionNameMapping = NULL)
+
+  expect_true("synRestGetAsync" %in% names(captured))
 })

--- a/tests/testthat/test_PythonPkgWrapperUtils.R
+++ b/tests/testthat/test_PythonPkgWrapperUtils.R
@@ -61,7 +61,10 @@ test_that("addPrefix works with three-part snake_case", {
 # ---------------------------------------------------------------------------
 
 test_that("removeNulls removes NULL elements from a list", {
-  expect_equal(list("a", "b", "c"), removeNulls(list("a", NULL, "b", NULL, "c")))
+  expect_equal(
+    list("a", "b", "c"),
+    removeNulls(list("a", NULL, "b", NULL, "c"))
+  )
 })
 
 test_that("removeNulls returns list unchanged when no NULLs present", {
@@ -127,7 +130,12 @@ test_that("determineArgsAndKwArgs last value wins on duplicate keyword argument"
 # ---------------------------------------------------------------------------
 
 test_that(".createFormalArgs returns empty list for no-param function", {
-  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   expect_length(.createFormalArgs(pyParams), 0)
 })
 
@@ -142,12 +150,17 @@ test_that(".createFormalArgs creates required args with no defaults", {
   result <- .createFormalArgs(pyParams)
 
   expect_named(result, c("x", "y"))
-  expect_identical(result$x, quote(expr =))
-  expect_identical(result$y, quote(expr =))
+  expect_identical(result$x, quote(expr = ))
+  expect_identical(result$y, quote(expr = ))
 })
 
 test_that(".createFormalArgs strips self from arg list", {
-  pyParams <- list(args = list("self", "x"), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list("self", "x"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   result <- .createFormalArgs(pyParams)
   expect_true("x" %in% names(result))
   expect_false("self" %in% names(result))
@@ -164,7 +177,7 @@ test_that(".createFormalArgs assigns defaults to trailing args", {
   result <- .createFormalArgs(pyParams)
 
   expect_named(result, c("x", "y", "z"))
-  expect_identical(result$x, quote(expr =))
+  expect_identical(result$x, quote(expr = ))
   expect_identical(result$y, 10)
   expect_identical(result$z, "hello")
 })
@@ -180,8 +193,8 @@ test_that(".createFormalArgs adds dots when varargs is present", {
   result <- .createFormalArgs(pyParams)
 
   expect_named(result, c("x", "..."))
-  expect_identical(result$x, quote(expr =))
-  expect_identical(result$..., quote(expr =))
+  expect_identical(result$x, quote(expr = ))
+  expect_identical(result$..., quote(expr = ))
 })
 
 test_that(".createFormalArgs adds dots when keywords is present", {
@@ -195,8 +208,8 @@ test_that(".createFormalArgs adds dots when keywords is present", {
   result <- .createFormalArgs(pyParams)
 
   expect_named(result, c("x", "..."))
-  expect_identical(result$x, quote(expr =))
-  expect_identical(result$..., quote(expr =))
+  expect_identical(result$x, quote(expr = ))
+  expect_identical(result$..., quote(expr = ))
 })
 
 test_that(".createFormalArgs handles no args but varargs present", {
@@ -210,19 +223,25 @@ test_that(".createFormalArgs handles no args but varargs present", {
   result <- .createFormalArgs(pyParams)
 
   expect_named(result, "...")
-  expect_identical(result$..., quote(expr =))
+  expect_identical(result$..., quote(expr = ))
 })
 # ---------------------------------------------------------------------------
 # applyFunctionNameMapping
 # ---------------------------------------------------------------------------
 
 test_that("applyFunctionNameMapping returns default name when no mapping", {
-  expect_equal("synFindEntityId", applyFunctionNameMapping("synFindEntityId", NULL))
+  expect_equal(
+    "synFindEntityId",
+    applyFunctionNameMapping("synFindEntityId", NULL)
+  )
 })
 
 test_that("applyFunctionNameMapping applies explicit mapping", {
   mapping <- list(explicit = list("synFromPathFile" = "synGetFileFromPath"))
-  expect_equal("synGetFileFromPath", applyFunctionNameMapping("synFromPathFile", mapping))
+  expect_equal(
+    "synGetFileFromPath",
+    applyFunctionNameMapping("synFromPathFile", mapping)
+  )
 })
 
 test_that("applyFunctionNameMapping returns default when name not in map", {
@@ -232,11 +251,26 @@ test_that("applyFunctionNameMapping returns default when name not in map", {
 
 test_that("applyFunctionNameMapping applies all predefined synapseClient models mappings", {
   mapping <- .synapseClientModelsMapping()
-  expect_equal("synDisassociateActivityFromEntity", applyFunctionNameMapping("synDisassociateFromEntity", mapping))
-  expect_equal("synGetFromPath",                    applyFunctionNameMapping("synFromPath",               mapping))
-  expect_equal("synInviteToTeam",                   applyFunctionNameMapping("synInvite",                 mapping))
-  expect_equal("synGetTeamMembers",                 applyFunctionNameMapping("synMembers",                mapping))
-  expect_equal("synGetOpenInvitations",             applyFunctionNameMapping("synOpenInvitations",        mapping))
+  expect_equal(
+    "synDisassociateActivityFromEntity",
+    applyFunctionNameMapping("synDisassociateFromEntity", mapping)
+  )
+  expect_equal(
+    "synGetFromPath",
+    applyFunctionNameMapping("synFromPath", mapping)
+  )
+  expect_equal(
+    "synInviteToTeam",
+    applyFunctionNameMapping("synInvite", mapping)
+  )
+  expect_equal(
+    "synGetTeamMembers",
+    applyFunctionNameMapping("synMembers", mapping)
+  )
+  expect_equal(
+    "synGetOpenInvitations",
+    applyFunctionNameMapping("synOpenInvitations", mapping)
+  )
 })
 
 # ---------------------------------------------------------------------------
@@ -282,7 +316,9 @@ test_that("cleanUpStackTrace extracts message after boundary marker in non-verbo
   on.exit(options(verbose = old_verbose))
   options(verbose = FALSE)
 
-  callable <- function() stop("python traceback\nexception-message-boundary\nclean user message")
+  callable <- function() {
+    stop("python traceback\nexception-message-boundary\nclean user message")
+  }
   err <- tryCatch(
     cleanUpStackTrace(callable, list()),
     error = function(e) e$message
@@ -296,7 +332,9 @@ test_that("cleanUpStackTrace preserves full error when verbose is TRUE", {
   on.exit(options(verbose = old_verbose))
   options(verbose = TRUE)
 
-  callable <- function() stop("python traceback\nexception-message-boundary\nclean user message")
+  callable <- function() {
+    stop("python traceback\nexception-message-boundary\nclean user message")
+  }
   err <- tryCatch(
     cleanUpStackTrace(callable, list()),
     error = function(e) e$message
@@ -339,7 +377,7 @@ test_that("autoGenerateEnum calls defineEnum for every entry in enumInfo", {
     received[[name]] <<- list(keys = keys, values = values)
   }
   enumInfo <- list(
-    list(name = "Enum1", keys = c("A"),      values = c(1L)),
+    list(name = "Enum1", keys = c("A"), values = c(1L)),
     list(name = "Enum2", keys = c("X", "Y"), values = c(10L, 20L))
   )
   autoGenerateEnum(mockCallback, enumInfo)
@@ -351,7 +389,9 @@ test_that("autoGenerateEnum calls defineEnum for every entry in enumInfo", {
 
 test_that("autoGenerateEnum is a no-op for empty enumInfo", {
   called <- FALSE
-  mockCallback <- function(name, keys, values) { called <<- TRUE }
+  mockCallback <- function(name, keys, values) {
+    called <<- TRUE
+  }
   autoGenerateEnum(mockCallback, list())
   expect_false(called)
 })
@@ -470,9 +510,12 @@ test_that("getExample matches Example: (single colon)", {
 # ---------------------------------------------------------------------------
 
 test_that("changeSphinxHyperlinksToLatex converts Sphinx links to \\href", {
-  raw    <- "`link text <http://example.com>`_"
+  raw <- "`link text <http://example.com>`_"
   result <- changeSphinxHyperlinksToLatex(raw)
-  expect_true(grepl("\\\\href\\{http://example\\.com\\}\\{link text\\}", result))
+  expect_true(grepl(
+    "\\\\href\\{http://example\\.com\\}\\{link text\\}",
+    result
+  ))
 })
 
 test_that("changeSphinxHyperlinksToLatex leaves plain text unchanged", {
@@ -481,7 +524,7 @@ test_that("changeSphinxHyperlinksToLatex leaves plain text unchanged", {
 })
 
 test_that("convertSphinxToLatex delegates to changeSphinxHyperlinksToLatex", {
-  raw    <- "`text <http://example.com>`_"
+  raw <- "`text <http://example.com>`_"
   expect_equal(changeSphinxHyperlinksToLatex(raw), convertSphinxToLatex(raw))
 })
 
@@ -490,7 +533,7 @@ test_that("convertSphinxToLatex delegates to changeSphinxHyperlinksToLatex", {
 # ---------------------------------------------------------------------------
 
 test_that("insertLatexNewLines replaces newlines with \\cr newlines", {
-  raw    <- "line1\nline2"
+  raw <- "line1\nline2"
   result <- insertLatexNewLines(raw)
   expect_equal("line1\\cr\nline2", result)
 })
@@ -501,7 +544,7 @@ test_that("insertLatexNewLines leaves string without newlines unchanged", {
 })
 
 test_that("insertLatexNewLines handles multiple newlines", {
-  raw    <- "a\nb\nc"
+  raw <- "a\nb\nc"
   result <- insertLatexNewLines(raw)
   expect_equal("a\\cr\nb\\cr\nc", result)
 })
@@ -562,29 +605,29 @@ test_that("formatArgsForArgumentSection returns empty string for no args", {
 
 test_that("formatArgsForArgumentSection produces \\item entries for each arg", {
   argNames <- list("entity", "version")
-  argDesc  <- list(entity = "The entity", version = "Version number")
-  result   <- formatArgsForArgumentSection(argNames, argDesc)
+  argDesc <- list(entity = "The entity", version = "Version number")
+  result <- formatArgsForArgumentSection(argNames, argDesc)
   expect_true(grepl("\\\\item\\{entity\\}", result))
   expect_true(grepl("\\\\item\\{version\\}", result))
 })
 
 test_that("formatArgsForArgumentSection uses empty description when arg not in docstring", {
   argNames <- list("entity")
-  result   <- formatArgsForArgumentSection(argNames, list())
+  result <- formatArgsForArgumentSection(argNames, list())
   expect_true(grepl("\\\\item\\{entity\\}\\{\\}", result))
 })
 
 test_that("formatArgsForArgumentSection skips self as first arg", {
   argNames <- list("self", "entity")
-  result   <- formatArgsForArgumentSection(argNames, list())
+  result <- formatArgsForArgumentSection(argNames, list())
   expect_false(grepl("\\{self\\}", result))
   expect_true(grepl("\\{entity\\}", result))
 })
 
 test_that("formatArgsForArgumentSection marks extra docstring args as optional named parameters", {
   argNames <- list("entity")
-  argDesc  <- list(entity = "The entity", extraArg = "An optional kwarg")
-  result   <- formatArgsForArgumentSection(argNames, argDesc)
+  argDesc <- list(entity = "The entity", extraArg = "An optional kwarg")
+  result <- formatArgsForArgumentSection(argNames, argDesc)
   expect_true(grepl("optional named parameter", result))
   expect_true(grepl("extraArg", result))
 })
@@ -604,7 +647,10 @@ test_that("usage lists all args with no defaults", {
 })
 
 test_that("usage appends =value for defaulted args", {
-  args <- list(args = list("entity", "version", "followLink"), defaults = list(NULL, FALSE))
+  args <- list(
+    args = list("entity", "version", "followLink"),
+    defaults = list(NULL, FALSE)
+  )
   result <- usage("myFunc", args, list())
   expect_true(grepl("version=NULL", result))
   expect_true(grepl("followLink=FALSE", result))
@@ -621,9 +667,9 @@ test_that("usage skips typ as first arg", {
 })
 
 test_that("usage appends extra docstring kwargs as arg=NULL", {
-  args    <- list(args = list("entity"), defaults = list())
+  args <- list(args = list("entity"), defaults = list())
   argDesc <- list(entity = "the entity", extraParam = "a kwarg")
-  result  <- usage("myFunc", args, argDesc)
+  result <- usage("myFunc", args, argDesc)
   expect_true(grepl("extraParam=NULL", result))
 })
 
@@ -637,27 +683,27 @@ test_that("parseArgDescriptionsFromDetails returns empty list for plain descript
 })
 
 test_that("parseArgDescriptionsFromDetails extracts single :param: description", {
-  doc    <- "A function.\n:param name: the entity name"
+  doc <- "A function.\n:param name: the entity name"
   result <- parseArgDescriptionsFromDetails(doc)
   expect_true("name" %in% names(result))
   expect_true(grepl("entity name", result$name))
 })
 
 test_that("parseArgDescriptionsFromDetails extracts multiple :param: descriptions", {
-  doc    <- ":param entity: the synapse entity\n:param version: the version number"
+  doc <- ":param entity: the synapse entity\n:param version: the version number"
   result <- parseArgDescriptionsFromDetails(doc)
-  expect_true("entity"  %in% names(result))
+  expect_true("entity" %in% names(result))
   expect_true("version" %in% names(result))
 })
 
 test_that("parseArgDescriptionsFromDetails truncates description at double newline", {
-  doc    <- ":param name: the name\n\nExtra text that should be excluded"
+  doc <- ":param name: the name\n\nExtra text that should be excluded"
   result <- parseArgDescriptionsFromDetails(doc)
   expect_false(grepl("Extra text", result$name))
 })
 
 test_that("parseArgDescriptionsFromDetails accepts :parameter: keyword as well", {
-  doc    <- ":parameter entity: the synapse entity"
+  doc <- ":parameter entity: the synapse entity"
   result <- parseArgDescriptionsFromDetails(doc)
   expect_true("entity" %in% names(result))
 })
@@ -667,77 +713,120 @@ test_that("parseArgDescriptionsFromDetails accepts :parameter: keyword as well",
 # ---------------------------------------------------------------------------
 
 test_that("generateFunctionalInterfaceInfo returns empty list for class with no methods", {
-  classInfo <- list(list(name = "MyClass", methods = NULL, constructorArgs = list(), doc = ""))
+  classInfo <- list(list(
+    name = "MyClass",
+    methods = NULL,
+    constructorArgs = list(),
+    doc = ""
+  ))
   expect_equal(list(), generateFunctionalInterfaceInfo(classInfo))
 })
 
 test_that("generateFunctionalInterfaceInfo skips the constructor method", {
   classInfo <- list(list(
-    name    = "MyClass",
+    name = "MyClass",
     methods = list(list(
-      name = "MyClass", doc = "",
-      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+      name = "MyClass",
+      doc = "",
+      args = list(
+        args = list("self"),
+        defaults = list(),
+        varargs = NULL,
+        keywords = NULL
+      )
     )),
-    constructorArgs = list(), doc = ""
+    constructorArgs = list(),
+    doc = ""
   ))
   expect_equal(list(), generateFunctionalInterfaceInfo(classInfo))
 })
 
 test_that("generateFunctionalInterfaceInfo creates correct generic name with syn prefix", {
   classInfo <- list(list(
-    name    = "File",
+    name = "File",
     methods = list(list(
-      name = "get", doc = "",
-      args = list(args = list("self", "synapse_id"), defaults = list(), varargs = NULL, keywords = NULL)
+      name = "get",
+      doc = "",
+      args = list(
+        args = list("self", "synapse_id"),
+        defaults = list(),
+        varargs = NULL,
+        keywords = NULL
+      )
     )),
-    constructorArgs = list(), doc = ""
+    constructorArgs = list(),
+    doc = ""
   ))
   result <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
-  expect_equal(1L,       length(result))
+  expect_equal(1L, length(result))
   expect_equal("synGet", result[[1]]$rName)
-  expect_equal("File",   result[[1]]$targetClass)
+  expect_equal("File", result[[1]]$targetClass)
   expect_true("synapse_id" %in% result[[1]]$args$args)
 })
 
 test_that("generateFunctionalInterfaceInfo strips self and does not add instance", {
   classInfo <- list(list(
-    name    = "File",
+    name = "File",
     methods = list(list(
-      name = "store", doc = "",
-      args = list(args = list("self", "force"), defaults = list(), varargs = NULL, keywords = NULL)
+      name = "store",
+      doc = "",
+      args = list(
+        args = list("self", "force"),
+        defaults = list(),
+        varargs = NULL,
+        keywords = NULL
+      )
     )),
-    constructorArgs = list(), doc = ""
+    constructorArgs = list(),
+    doc = ""
   ))
   result <- generateFunctionalInterfaceInfo(classInfo)
-  args   <- result[[1]]$args$args
-  expect_false("self"     %in% args)
+  args <- result[[1]]$args$args
+  expect_false("self" %in% args)
   expect_false("instance" %in% args)
-  expect_true("force"     %in% args)
+  expect_true("force" %in% args)
 })
 
 test_that("generateFunctionalInterfaceInfo applies function name mapping", {
   classInfo <- list(list(
-    name    = "Team",
+    name = "Team",
     methods = list(list(
-      name = "invite", doc = "",
-      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+      name = "invite",
+      doc = "",
+      args = list(
+        args = list("self"),
+        defaults = list(),
+        varargs = NULL,
+        keywords = NULL
+      )
     )),
-    constructorArgs = list(), doc = ""
+    constructorArgs = list(),
+    doc = ""
   ))
   mapping <- list(explicit = list("synInvite" = "synInviteToTeam"))
-  result  <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn",
-                                             functionNameMapping = mapping)
+  result <- generateFunctionalInterfaceInfo(
+    classInfo,
+    functionPrefix = "syn",
+    functionNameMapping = mapping
+  )
   expect_equal("synInviteToTeam", result[[1]]$rName)
 })
 
 test_that("generateFunctionalInterfaceInfo sets functionContainerName to ClassName.methodName", {
   classInfo <- list(list(
-    name    = "File",
+    name = "File",
     methods = list(list(
-      name = "get_acl", doc = "",
-      args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+      name = "get_acl",
+      doc = "",
+      args = list(
+        args = list("self"),
+        defaults = list(),
+        varargs = NULL,
+        keywords = NULL
+      )
     )),
-    constructorArgs = list(), doc = ""
+    constructorArgs = list(),
+    doc = ""
   ))
   result <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
   expect_equal("File.get_acl", result[[1]]$functionContainerName)
@@ -746,32 +835,58 @@ test_that("generateFunctionalInterfaceInfo sets functionContainerName to ClassNa
 test_that("generateFunctionalInterfaceInfo iterates all classes and all methods", {
   classInfo <- list(
     list(
-      name    = "File",
+      name = "File",
       methods = list(
-        list(name = "get_acl", doc = "",
-             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)),
-        list(name = "snapshot", doc = "",
-             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL))
+        list(
+          name = "get_acl",
+          doc = "",
+          args = list(
+            args = list("self"),
+            defaults = list(),
+            varargs = NULL,
+            keywords = NULL
+          )
+        ),
+        list(
+          name = "snapshot",
+          doc = "",
+          args = list(
+            args = list("self"),
+            defaults = list(),
+            varargs = NULL,
+            keywords = NULL
+          )
+        )
       ),
-      constructorArgs = list(), doc = ""
+      constructorArgs = list(),
+      doc = ""
     ),
     list(
-      name    = "Project",
+      name = "Project",
       methods = list(
-        list(name = "delete", doc = "",
-             args = list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL))
+        list(
+          name = "delete",
+          doc = "",
+          args = list(
+            args = list("self"),
+            defaults = list(),
+            varargs = NULL,
+            keywords = NULL
+          )
+        )
       ),
-      constructorArgs = list(), doc = ""
+      constructorArgs = list(),
+      doc = ""
     )
   )
-  result        <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
-  rNames        <- sapply(result, function(x) x$rName)
+  result <- generateFunctionalInterfaceInfo(classInfo, functionPrefix = "syn")
+  rNames <- sapply(result, function(x) x$rName)
   targetClasses <- sapply(result, function(x) x$targetClass)
 
   expect_equal(3L, length(result))
-  expect_true("synGetAcl"   %in% rNames)
+  expect_true("synGetAcl" %in% rNames)
   expect_true("synSnapshot" %in% rNames)
-  expect_true("synDelete"   %in% rNames)
+  expect_true("synDelete" %in% rNames)
   expect_equal(2L, sum(targetClasses == "File"))
   expect_equal(1L, sum(targetClasses == "Project"))
 })
@@ -783,9 +898,16 @@ test_that("generateFunctionalInterfaceInfo iterates all classes and all methods"
 test_that("defineConstructor calls setGenericCallback with the class name", {
   # stand-in for setGeneric; records registered functions by name
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineConstructor("synapseclient.models", mockCb, "File", pyParams)
 
   expect_true("File" %in% names(captured))
@@ -794,9 +916,16 @@ test_that("defineConstructor calls setGenericCallback with the class name", {
 test_that("defineConstructor registers a no-arg constructor with empty formals", {
   # stand-in for setGeneric; records registered functions by name
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineConstructor("synapseclient.models", mockCb, "Project", pyParams)
 
   expect_length(formals(captured[["Project"]]), 1) # the ... in rFn
@@ -805,32 +934,36 @@ test_that("defineConstructor registers a no-arg constructor with empty formals",
 test_that("defineConstructor registers correct formals from pyParams args and defaults", {
   # stand-in for setGeneric; records registered functions by name
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }  
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
   pyParams <- list(
-    args     = list("name", "parent", "description"),
+    args = list("name", "parent", "description"),
     defaults = list("text"),
-    varargs  = NULL,
+    varargs = NULL,
     keywords = NULL
   )
   defineConstructor("synapseclient.models", mockCb, "Folder", pyParams)
 
   fn_formals <- formals(captured[["Folder"]])
   expect_named(fn_formals, c("name", "parent", "description"))
-  expect_identical(fn_formals$name,        quote(expr =))
-  expect_identical(fn_formals$parent,      quote(expr =))
+  expect_identical(fn_formals$name, quote(expr = ))
+  expect_identical(fn_formals$parent, quote(expr = ))
   expect_identical(fn_formals$description, "text")
 })
 
 test_that("defineConstructor adds dots when pyParams has keywords", {
   # stand-in for setGeneric; records registered functions by name
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
   pyParams <- list(
-    args     = list("name"),
+    args = list("name"),
     defaults = list(),
-    varargs  = NULL,
+    varargs = NULL,
     keywords = "kwargs"
   )
   defineConstructor("synapseclient.models", mockCb, "Table", pyParams)
@@ -841,9 +974,11 @@ test_that("defineConstructor adds dots when pyParams has keywords", {
 test_that("defineConstructor registered function prepends class name to returned object's class vector", {
   # Mock gateway$invoke so no real Python constructor is called
   # unlockBinding is needed because a prior test may have called .getGateway()
-  ns               <- environment(defineConstructor)
+  ns <- environment(defineConstructor)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
@@ -851,9 +986,16 @@ test_that("defineConstructor registered function prepends class name to returned
   reticulate::py_run_string("import sys")
 
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list(), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list(),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineConstructor("sys", mockCb, "File", pyParams)
 
   result <- captured[["File"]]()
@@ -868,14 +1010,23 @@ test_that("defineConstructor registered function prepends class name to returned
 test_that("defineClassMethod registers function as ClassName_methodName", {
   ns <- environment(defineClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
   # stand-in for setGeneric; records registered functions by name
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
 
   expect_true("File_get" %in% names(captured))
@@ -888,34 +1039,45 @@ test_that("defineClassMethod puts instance as first formal and drops self", {
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
   pyParams <- list(
-    args     = list("self", "entity", "version"),
+    args = list("self", "entity", "version"),
     defaults = list(NULL),
-    varargs  = NULL,
+    varargs = NULL,
     keywords = NULL
   )
   defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
 
   fn_formals <- names(formals(captured[["File_get"]]))
   expect_equal("instance", fn_formals[1])
-  expect_false("self"    %in% fn_formals)
-  expect_true("entity"   %in% fn_formals)
-  expect_true("version"  %in% fn_formals)
+  expect_false("self" %in% fn_formals)
+  expect_true("entity" %in% fn_formals)
+  expect_true("version" %in% fn_formals)
 })
 
 test_that("defineClassMethod adds dots when pyParams has keywords", {
   ns <- environment(defineClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = "kwargs")
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = "kwargs"
+  )
   defineClassMethod("synapseclient.models", mockCb, "File", "store", pyParams)
 
   expect_true("..." %in% names(formals(captured[["File_store"]])))
@@ -924,16 +1086,31 @@ test_that("defineClassMethod adds dots when pyParams has keywords", {
 test_that("defineClassMethod R function name comes from methodName, not pythonMethodName", {
   ns <- environment(defineClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
-  defineClassMethod("synapseclient.models", mockCb, "File", "store", pyParams,
-                    pythonMethodName = "store_async")
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  defineClassMethod(
+    "synapseclient.models",
+    mockCb,
+    "File",
+    "store",
+    pyParams,
+    pythonMethodName = "store_async"
+  )
 
   expect_true("File_store" %in% names(captured))
 })
@@ -941,14 +1118,23 @@ test_that("defineClassMethod R function name comes from methodName, not pythonMe
 test_that("defineClassMethod calling wrapper with NULL instance errors with class name", {
   ns <- environment(defineClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb   <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineClassMethod("synapseclient.models", mockCb, "File", "get", pyParams)
 
   expect_error(captured[["File_get"]](NULL), regexp = "File")
@@ -961,12 +1147,24 @@ test_that("defineClassMethod calling wrapper with NULL instance errors with clas
 test_that("defineFunctionalClassMethod registers a generic name for the method", {
   ns <- environment(defineFunctionalClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
-  defineFunctionalClassMethod("synapseclient.models", "Project", "store", pyParams)
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  defineFunctionalClassMethod(
+    "synapseclient.models",
+    "Project",
+    "store",
+    pyParams
+  )
 
   expect_true(exists("synStore", mode = "function", inherits = TRUE))
   expect_false(exists("synStoreProject", mode = "function", inherits = TRUE))
@@ -975,16 +1173,31 @@ test_that("defineFunctionalClassMethod registers a generic name for the method",
 test_that("defineFunctionalClassMethod stores inner worker in dispatch table", {
   ns <- environment(defineFunctionalClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineFunctionalClassMethod("synapseclient.models", "File", "store", pyParams)
 
-  expect_true(exists("synStore_File", envir = .functionalMethodDispatch, inherits = FALSE))
+  expect_true(exists(
+    "synStore_File",
+    envir = .functionalMethodDispatch,
+    inherits = FALSE
+  ))
 
-  worker <- get("synStore_File", envir = .functionalMethodDispatch, inherits = FALSE)
+  worker <- get(
+    "synStore_File",
+    envir = .functionalMethodDispatch,
+    inherits = FALSE
+  )
   expect_true(is.function(worker))
   expect_equal("instance", names(formals(worker))[1])
 
@@ -995,55 +1208,9 @@ test_that("defineFunctionalClassMethod stores inner worker in dispatch table", {
 test_that("defineFunctionalClassMethod generic errors with pipe-hint when called without instance", {
   ns <- environment(defineFunctionalClassMethod)
   original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
-  assign(".gateway", list(invoke = function(...) list()), envir = ns)
-  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
-
-  # Use get_acl — not a real registered function — so defineFunctionalClassMethod
-  # registers a fresh generic rather than skipping due to the !exists() guard.
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
-  defineFunctionalClassMethod("synapseclient.models", "Project", "get_acl", pyParams)
-
-  fn <- get("synGetAcl")
-  expect_error(fn(), regexp = "Pass an object as the first argument, e.g. ClassName\\(...\\) \\|> synGetAcl\\(\\)")
-})
-
-test_that("defineFunctionalClassMethod generic errors for unregistered class", {
-  ns <- environment(defineFunctionalClassMethod)
-  original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
-  assign(".gateway", list(invoke = function(...) list()), envir = ns)
-  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
-
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
-  defineFunctionalClassMethod("synapseclient.models", "Project", "get_acl", pyParams)
-
-  fn  <- get("synGetAcl")
-  obj <- structure(list(), class = "UnknownClass")
-  expect_error(fn(obj), regexp = "No 'synGetAcl' method registered for class 'UnknownClass'")
-})
-
-test_that("defineFunctionalClassMethod applies functionNameMapping to generic name", {
-  ns <- environment(defineFunctionalClassMethod)
-  original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
-  assign(".gateway", list(invoke = function(...) list()), envir = ns)
-  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
-
-  pyParams <- list(args = list("self"), defaults = list(), varargs = NULL, keywords = NULL)
-  mapping  <- list(explicit = list("synInvite" = "synInviteToTeam"))
-  defineFunctionalClassMethod("synapseclient.models", "Team", "invite", pyParams,
-                              functionNameMapping = mapping)
-
-  expect_true(exists("synInviteToTeam", mode = "function", inherits = TRUE))
-  expect_false(exists("synInviteTeam",  mode = "function", inherits = TRUE))
-  expect_true(exists("synInviteToTeam_Team", envir = .functionalMethodDispatch, inherits = FALSE))
-})
-
-test_that("defineFunctionalClassMethod static: registers plain function without instance formal", {
-  ns <- environment(defineFunctionalClassMethod)
-  original_gateway <- get(".gateway", envir = ns)
-  if (bindingIsLocked(".gateway", ns)) unlockBinding(".gateway", ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
   assign(".gateway", list(invoke = function(...) list()), envir = ns)
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
@@ -1051,10 +1218,142 @@ test_that("defineFunctionalClassMethod static: registers plain function without 
   localDefineFunctionalClassMethod <- defineFunctionalClassMethod
   environment(localDefineFunctionalClassMethod) <- localNs
 
-  pyParams <- list(args = list("query"), defaults = list(), varargs = NULL, keywords = NULL)
-  localDefineFunctionalClassMethod("synapseclient.models", "Table", "query", pyParams, isStatic = TRUE)
+  # Use get_acl — not a real registered function — so defineFunctionalClassMethod
+  # registers a fresh generic rather than skipping due to the !exists() guard.
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "synapseclient.models",
+    "Project",
+    "get_acl",
+    pyParams
+  )
 
-  expect_true(exists("synQuery", envir = localNs, mode = "function", inherits = FALSE))
+  fn <- get("synGetAcl", envir = localNs)
+  expect_error(
+    fn(),
+    regexp = "Pass an object as the first argument, e.g. ClassName\\(...\\) \\|> synGetAcl\\(\\)"
+  )
+})
+
+test_that("defineFunctionalClassMethod generic errors for unregistered class", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  localNs <- new.env(parent = ns)
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "synapseclient.models",
+    "Project",
+    "get_acl",
+    pyParams
+  )
+
+  fn <- get("synGetAcl", envir = localNs)
+  obj <- structure(list(), class = "UnknownClass")
+  expect_error(
+    fn(obj),
+    regexp = "No 'synGetAcl' method registered for class 'UnknownClass'"
+  )
+})
+
+test_that("defineFunctionalClassMethod applies functionNameMapping to generic name", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  localNs <- new.env(parent = ns)
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("self"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  mapping <- list(explicit = list("synInvite" = "synInviteToTeam"))
+  localDefineFunctionalClassMethod(
+    "synapseclient.models",
+    "Team",
+    "invite",
+    pyParams,
+    functionNameMapping = mapping
+  )
+
+  expect_true(exists(
+    "synInviteToTeam",
+    envir = localNs,
+    mode = "function",
+    inherits = FALSE
+  ))
+  expect_false(exists(
+    "synInviteTeam",
+    envir = localNs,
+    mode = "function",
+    inherits = FALSE
+  ))
+  expect_true(exists(
+    "synInviteToTeam_Team",
+    envir = .functionalMethodDispatch,
+    inherits = FALSE
+  ))
+})
+
+test_that("defineFunctionalClassMethod static: registers plain function without instance formal", {
+  ns <- environment(defineFunctionalClassMethod)
+  original_gateway <- get(".gateway", envir = ns)
+  if (bindingIsLocked(".gateway", ns)) {
+    unlockBinding(".gateway", ns)
+  }
+  assign(".gateway", list(invoke = function(...) list()), envir = ns)
+  on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
+
+  localNs <- new.env(parent = ns)
+  localDefineFunctionalClassMethod <- defineFunctionalClassMethod
+  environment(localDefineFunctionalClassMethod) <- localNs
+
+  pyParams <- list(
+    args = list("query"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
+  localDefineFunctionalClassMethod(
+    "synapseclient.models",
+    "Table",
+    "query",
+    pyParams,
+    isStatic = TRUE
+  )
+
+  expect_true(exists(
+    "synQuery",
+    envir = localNs,
+    mode = "function",
+    inherits = FALSE
+  ))
   expect_false("instance" %in% names(formals(get("synQuery", envir = localNs))))
   expect_true("query" %in% names(formals(get("synQuery", envir = localNs))))
 })
@@ -1070,8 +1369,15 @@ test_that("defineFunction registers function under the given R name", {
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb <- function(name, def) { captured[[name]] <<- def }
-  pyParams <- list(args = list("synapse_id"), defaults = list(), varargs = NULL, keywords = NULL)
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
+  pyParams <- list(
+    args = list("synapse_id"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = NULL
+  )
   defineFunction("synGet", "get", "synapseclient.operations", pyParams, mockCb)
 
   expect_true("synGet" %in% names(captured))
@@ -1085,18 +1391,20 @@ test_that("defineFunction creates formals matching pyParams args", {
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
   pyParams <- list(
-    args     = list("entity", "version", "downloadFile"),
+    args = list("entity", "version", "downloadFile"),
     defaults = list(NULL, TRUE),
-    varargs  = NULL,
+    varargs = NULL,
     keywords = NULL
   )
   defineFunction("synGet", "get", "synapseclient.operations", pyParams, mockCb)
 
   fn_formals <- formals(captured[["synGet"]])
   expect_equal(c("entity", "version", "downloadFile"), names(fn_formals))
-  expect_identical(fn_formals$version,      NULL)
+  expect_identical(fn_formals$version, NULL)
   expect_identical(fn_formals$downloadFile, TRUE)
 })
 
@@ -1107,11 +1415,22 @@ test_that("defineFunction adds dots and preserves args when pyParams has varargs
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb <- function(name, def) { captured[[name]] <<- def }
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
 
-  defineFunction("synStore", "store", "synapseclient.operations",
-                 list(args = list("entity"), defaults = list(), varargs = "args", keywords = NULL),
-                 mockCb)
+  defineFunction(
+    "synStore",
+    "store",
+    "synapseclient.operations",
+    list(
+      args = list("entity"),
+      defaults = list(),
+      varargs = "args",
+      keywords = NULL
+    ),
+    mockCb
+  )
   varargs_formals <- names(formals(captured[["synStore"]]))
   expect_true("entity" %in% varargs_formals)
   expect_true("..." %in% varargs_formals)
@@ -1124,9 +1443,22 @@ test_that("defineFunction synStore has entity as first formal for pipe compatibi
   on.exit(assign(".gateway", original_gateway, envir = ns), add = TRUE)
 
   captured <- list()
-  mockCb <- function(name, def) { captured[[name]] <<- def }
-  pyParams <- list(args = list("entity"), defaults = list(), varargs = NULL, keywords = "kwargs")
-  defineFunction("synStore", "store", "synapseclient.operations", pyParams, mockCb)
+  mockCb <- function(name, def) {
+    captured[[name]] <<- def
+  }
+  pyParams <- list(
+    args = list("entity"),
+    defaults = list(),
+    varargs = NULL,
+    keywords = "kwargs"
+  )
+  defineFunction(
+    "synStore",
+    "store",
+    "synapseclient.operations",
+    pyParams,
+    mockCb
+  )
 
   expect_equal("entity", names(formals(captured[["synStore"]]))[1])
 })

--- a/tests/testthat/test_shared.R
+++ b/tests/testthat/test_shared.R
@@ -1,3 +1,6 @@
+# One way to run the test is to run the test using devtools::test(filter = "shared")
+# from the synapser package directory.
+
 context("test shared filter functions and operations functions")
 
 # ---------------------------------------------------------------------------
@@ -30,11 +33,22 @@ test_that(".removeAllClassesClassFilter always returns NULL", {
 # ---------------------------------------------------------------------------
 
 test_that(".synapseClassFunctionFilter passes through included methods", {
-  for (methodName in c("login", "logout", "setEndpoints", "sendMessage",
-                       "restGET", "restPUT", "restPOST", "restDELETE")) {
+  for (methodName in c(
+    "login",
+    "logout",
+    "setEndpoints",
+    "sendMessage",
+    "rest_get_async",
+    "rest_put_async",
+    "rest_post_async",
+    "rest_delete_async"
+  )) {
     x <- list(name = methodName)
-    expect_equal(x, .synapseClassFunctionFilter(x),
-                 info = paste("should pass through", methodName))
+    expect_equal(
+      x,
+      .synapseClassFunctionFilter(x),
+      info = paste("should pass through", methodName)
+    )
   }
 })
 
@@ -63,7 +77,7 @@ test_that(".removeAsyncFunctionFilter passes through non-async functions", {
   expect_equal(x, .removeAsyncFunctionFilter(x))
   x2 <- list(name = "store")
   expect_equal(x2, .removeAsyncFunctionFilter(x2))
-  x3 <- list(name = "get_async_result")  # contains but does not end with _async
+  x3 <- list(name = "get_async_result") # contains but does not end with _async
   expect_equal(x3, .removeAsyncFunctionFilter(x3))
 })
 
@@ -78,14 +92,27 @@ test_that(".removeAsyncFunctionFilter returns NULL for _async-suffixed functions
 # ---------------------------------------------------------------------------
 
 test_that(".operationsFunctionNamesFilter passes through known operations", {
-  for (opName in c("get", "store", "delete", "download_list_files",
-                   "download_list_manifest", "download_list_add",
-                   "download_list_remove", "download_list_clear",
-                   "find_entity_id", "is_synapse_id", "md5_query",
-                   "onweb", "print_entity")) {
+  for (opName in c(
+    "get",
+    "store",
+    "delete",
+    "download_list_files",
+    "download_list_manifest",
+    "download_list_add",
+    "download_list_remove",
+    "download_list_clear",
+    "find_entity_id",
+    "is_synapse_id",
+    "md5_query",
+    "onweb",
+    "print_entity"
+  )) {
     x <- list(name = opName)
-    expect_equal(x, .operationsFunctionNamesFilter(x),
-                 info = paste("should pass through", opName))
+    expect_equal(
+      x,
+      .operationsFunctionNamesFilter(x),
+      info = paste("should pass through", opName)
+    )
   }
 })
 
@@ -100,12 +127,22 @@ test_that(".operationsFunctionNamesFilter returns NULL for non-operation names",
 # ---------------------------------------------------------------------------
 
 test_that(".synapseModelClassFilter returns NULL for classes not in the include list", {
-  expect_null(.synapseModelClassFilter(list(name = "NotAClass", methods = list())))
+  expect_null(.synapseModelClassFilter(list(
+    name = "NotAClass",
+    methods = list()
+  )))
   expect_null(.synapseModelClassFilter(list(name = "Synapse")))
 })
 
 test_that(".synapseModelClassFilter passes through included classes", {
-  for (className in c("Project", "Folder", "File", "Table", "Activity", "Team")) {
+  for (className in c(
+    "Project",
+    "Folder",
+    "File",
+    "Table",
+    "Activity",
+    "Team"
+  )) {
     x <- list(name = className, methods = list())
     result <- .synapseModelClassFilter(x)
     expect_false(is.null(result), info = paste("should include", className))
@@ -124,7 +161,7 @@ test_that(".synapseModelClassFilter strips _async methods from included classes"
   )
   result <- .synapseModelClassFilter(x)
   resultNames <- sapply(result$methods, `[[`, "name")
-  expect_true("from_id"         %in% resultNames)
+  expect_true("from_id" %in% resultNames)
   expect_true("set_permissions" %in% resultNames)
   expect_false("from_id_async" %in% resultNames)
 })
@@ -143,9 +180,9 @@ test_that(".synapseModelClassFilter strips methods in modelClassMethodsToOmit", 
   result <- .synapseModelClassFilter(x)
   resultNames <- sapply(result$methods, `[[`, "name")
   expect_true("from_id" %in% resultNames)
-  expect_false("format_for_manifest"  %in% resultNames)
-  expect_false("fill_from_dict"       %in% resultNames)
-  expect_false("to_synapse_request"   %in% resultNames)
+  expect_false("format_for_manifest" %in% resultNames)
+  expect_false("fill_from_dict" %in% resultNames)
+  expect_false("to_synapse_request" %in% resultNames)
   expect_false("allow_client_caching" %in% resultNames)
 })
 
@@ -161,14 +198,17 @@ test_that(".synapseModelClassFilter strips operations function names from class 
   )
   result <- .synapseModelClassFilter(x)
   resultNames <- sapply(result$methods, `[[`, "name")
-  expect_true("from_id"   %in% resultNames)
+  expect_true("from_id" %in% resultNames)
   expect_true("my_method" %in% resultNames)
-  expect_false("get"    %in% resultNames)
+  expect_false("get" %in% resultNames)
   expect_false("delete" %in% resultNames)
 })
 
 test_that(".synapseModelClassFilter handles class with excluded methods", {
-  x <- list(name = "File", methods = list(list(name = "get"), list(name = "from_id")))
+  x <- list(
+    name = "File",
+    methods = list(list(name = "get"), list(name = "from_id"))
+  )
   result <- .synapseModelClassFilter(x)
   expect_equal("File", result$name)
   expect_equal(1L, length(result$methods))
@@ -188,14 +228,17 @@ test_that(".synapseModelClassFilter returns all methods when none are filtered",
 })
 
 # ---------------------------------------------------------------------------
-# .synapseClientModelsMapping
+# .functionNameMapping
 # ---------------------------------------------------------------------------
 
-test_that(".synapseClientModelsMapping explicit map contains all expected entries", {
-  explicit <- .synapseClientModelsMapping()$explicit
-  expect_equal("synDisassociateActivityFromEntity", explicit[["synDisassociateFromEntity"]])
-  expect_equal("synGetFromPath",        explicit[["synFromPath"]])
-  expect_equal("synInviteToTeam",       explicit[["synInvite"]])
-  expect_equal("synGetTeamMembers",     explicit[["synMembers"]])
+test_that(".functionNameMappingSynapseclientModels explicit map contains all expected entries", {
+  explicit <- .functionNameMappingSynapseclientModels()$explicit
+  expect_equal(
+    "synDisassociateActivityFromEntity",
+    explicit[["synDisassociateFromEntity"]]
+  )
+  expect_equal("synGetFromPath", explicit[["synFromPath"]])
+  expect_equal("synInviteToTeam", explicit[["synInvite"]])
+  expect_equal("synGetTeamMembers", explicit[["synMembers"]])
   expect_equal("synGetOpenInvitations", explicit[["synOpenInvitations"]])
 })

--- a/tests/testthat/test_shared.R
+++ b/tests/testthat/test_shared.R
@@ -1,0 +1,201 @@
+context("test shared filter functions and operations functions")
+
+# ---------------------------------------------------------------------------
+# .cherryPickTableFunctionFilter
+# ---------------------------------------------------------------------------
+
+test_that(".cherryPickTableFunctionFilter passes through 'build_table'", {
+  x <- list(name = "build_table")
+  expect_equal(x, .cherryPickTableFunctionFilter(x))
+})
+
+test_that(".cherryPickTableFunctionFilter returns NULL for unrecognized names", {
+  expect_null(.cherryPickTableFunctionFilter(list(name = "Column")))
+  expect_null(.cherryPickTableFunctionFilter(list(name = "EntityView")))
+  expect_null(.cherryPickTableFunctionFilter(list(name = "")))
+})
+
+# ---------------------------------------------------------------------------
+# .removeAllClassesClassFilter
+# ---------------------------------------------------------------------------
+
+test_that(".removeAllClassesClassFilter always returns NULL", {
+  expect_null(.removeAllClassesClassFilter(list(name = "Synapse")))
+  expect_null(.removeAllClassesClassFilter(list(name = "File")))
+  expect_null(.removeAllClassesClassFilter(NULL))
+})
+
+# ---------------------------------------------------------------------------
+# .synapseClassFunctionFilter
+# ---------------------------------------------------------------------------
+
+test_that(".synapseClassFunctionFilter passes through included methods", {
+  for (methodName in c("login", "logout", "setEndpoints", "sendMessage",
+                       "restGET", "restPUT", "restPOST", "restDELETE")) {
+    x <- list(name = methodName)
+    expect_equal(x, .synapseClassFunctionFilter(x),
+                 info = paste("should pass through", methodName))
+  }
+})
+
+test_that(".synapseClassFunctionFilter returns NULL for excluded methods", {
+  expect_null(.synapseClassFunctionFilter(list(name = "get")))
+  expect_null(.synapseClassFunctionFilter(list(name = "store")))
+  expect_null(.synapseClassFunctionFilter(list(name = "some_other_method")))
+})
+
+# ---------------------------------------------------------------------------
+# .removeAllFunctionsFunctionFilter
+# ---------------------------------------------------------------------------
+
+test_that(".removeAllFunctionsFunctionFilter always returns NULL", {
+  expect_null(.removeAllFunctionsFunctionFilter(list(name = "get")))
+  expect_null(.removeAllFunctionsFunctionFilter(list(name = "login")))
+  expect_null(.removeAllFunctionsFunctionFilter(NULL))
+})
+
+# ---------------------------------------------------------------------------
+# .removeAsyncFunctionFilter
+# ---------------------------------------------------------------------------
+
+test_that(".removeAsyncFunctionFilter passes through non-async functions", {
+  x <- list(name = "get")
+  expect_equal(x, .removeAsyncFunctionFilter(x))
+  x2 <- list(name = "store")
+  expect_equal(x2, .removeAsyncFunctionFilter(x2))
+  x3 <- list(name = "get_async_result")  # contains but does not end with _async
+  expect_equal(x3, .removeAsyncFunctionFilter(x3))
+})
+
+test_that(".removeAsyncFunctionFilter returns NULL for _async-suffixed functions", {
+  expect_null(.removeAsyncFunctionFilter(list(name = "get_async")))
+  expect_null(.removeAsyncFunctionFilter(list(name = "store_async")))
+  expect_null(.removeAsyncFunctionFilter(list(name = "delete_async")))
+})
+
+# ---------------------------------------------------------------------------
+# .operationsFunctionNamesFilter
+# ---------------------------------------------------------------------------
+
+test_that(".operationsFunctionNamesFilter passes through known operations", {
+  for (opName in c("get", "store", "delete", "download_list_files",
+                   "download_list_manifest", "download_list_add",
+                   "download_list_remove", "download_list_clear",
+                   "find_entity_id", "is_synapse_id", "md5_query",
+                   "onweb", "print_entity")) {
+    x <- list(name = opName)
+    expect_equal(x, .operationsFunctionNamesFilter(x),
+                 info = paste("should pass through", opName))
+  }
+})
+
+test_that(".operationsFunctionNamesFilter returns NULL for non-operation names", {
+  expect_null(.operationsFunctionNamesFilter(list(name = "login")))
+  expect_null(.operationsFunctionNamesFilter(list(name = "get_async")))
+  expect_null(.operationsFunctionNamesFilter(list(name = "some_function")))
+})
+
+# ---------------------------------------------------------------------------
+# .synapseModelClassFilter
+# ---------------------------------------------------------------------------
+
+test_that(".synapseModelClassFilter returns NULL for classes not in the include list", {
+  expect_null(.synapseModelClassFilter(list(name = "NotAClass", methods = list())))
+  expect_null(.synapseModelClassFilter(list(name = "Synapse")))
+})
+
+test_that(".synapseModelClassFilter passes through included classes", {
+  for (className in c("Project", "Folder", "File", "Table", "Activity", "Team")) {
+    x <- list(name = className, methods = list())
+    result <- .synapseModelClassFilter(x)
+    expect_false(is.null(result), info = paste("should include", className))
+    expect_equal(className, result$name)
+  }
+})
+
+test_that(".synapseModelClassFilter strips _async methods from included classes", {
+  x <- list(
+    name = "File",
+    methods = list(
+      list(name = "from_id"),
+      list(name = "from_id_async"),
+      list(name = "set_permissions")
+    )
+  )
+  result <- .synapseModelClassFilter(x)
+  resultNames <- sapply(result$methods, `[[`, "name")
+  expect_true("from_id"         %in% resultNames)
+  expect_true("set_permissions" %in% resultNames)
+  expect_false("from_id_async" %in% resultNames)
+})
+
+test_that(".synapseModelClassFilter strips methods in modelClassMethodsToOmit", {
+  x <- list(
+    name = "File",
+    methods = list(
+      list(name = "from_id"),
+      list(name = "format_for_manifest"),
+      list(name = "fill_from_dict"),
+      list(name = "to_synapse_request"),
+      list(name = "allow_client_caching")
+    )
+  )
+  result <- .synapseModelClassFilter(x)
+  resultNames <- sapply(result$methods, `[[`, "name")
+  expect_true("from_id" %in% resultNames)
+  expect_false("format_for_manifest"  %in% resultNames)
+  expect_false("fill_from_dict"       %in% resultNames)
+  expect_false("to_synapse_request"   %in% resultNames)
+  expect_false("allow_client_caching" %in% resultNames)
+})
+
+test_that(".synapseModelClassFilter strips operations function names from class methods", {
+  x <- list(
+    name = "File",
+    methods = list(
+      list(name = "from_id"),
+      list(name = "get"),
+      list(name = "delete"),
+      list(name = "my_method")
+    )
+  )
+  result <- .synapseModelClassFilter(x)
+  resultNames <- sapply(result$methods, `[[`, "name")
+  expect_true("from_id"   %in% resultNames)
+  expect_true("my_method" %in% resultNames)
+  expect_false("get"    %in% resultNames)
+  expect_false("delete" %in% resultNames)
+})
+
+test_that(".synapseModelClassFilter handles class with excluded methods", {
+  x <- list(name = "File", methods = list(list(name = "get"), list(name = "from_id")))
+  result <- .synapseModelClassFilter(x)
+  expect_equal("File", result$name)
+  expect_equal(1L, length(result$methods))
+  expect_equal("from_id", result$methods[[1]]$name)
+})
+
+test_that(".synapseModelClassFilter returns all methods when none are filtered", {
+  x <- list(
+    name = "Project",
+    methods = list(
+      list(name = "from_id"),
+      list(name = "my_method")
+    )
+  )
+  result <- .synapseModelClassFilter(x)
+  expect_equal(2L, length(result$methods))
+})
+
+# ---------------------------------------------------------------------------
+# .synapseClientModelsMapping
+# ---------------------------------------------------------------------------
+
+test_that(".synapseClientModelsMapping explicit map contains all expected entries", {
+  explicit <- .synapseClientModelsMapping()$explicit
+  expect_equal("synDisassociateActivityFromEntity", explicit[["synDisassociateFromEntity"]])
+  expect_equal("synGetFromPath",        explicit[["synFromPath"]])
+  expect_equal("synInviteToTeam",       explicit[["synInvite"]])
+  expect_equal("synGetTeamMembers",     explicit[["synMembers"]])
+  expect_equal("synGetOpenInvitations", explicit[["synOpenInvitations"]])
+})

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -10,28 +10,35 @@ source(sprintf("%s/R/shared.R", srcRootDir))
 source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
 
 reticulate::py_run_string("import sys")
-reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(srcRootDir, "inst", "python")))
-## all functions in synapseclient.Synapse module
-generateRdFiles(srcRootDir,
-                pyPkg = "synapseclient",
-                container = "synapseclient.Synapse",
-                functionFilter = .synapseClassFunctionFilter,
-                functionPrefix = "syn")
+reticulate::py_run_string(sprintf(
+    "sys.path.append(\"%s\")",
+    file.path(srcRootDir, "inst", "python")
+))
+
+generateRdFiles(
+    srcRootDir,
+    pyPkg = "synapseclient",
+    container = "synapseclient.Synapse",
+    functionFilter = .synapseClassFunctionFilter,
+    functionPrefix = "syn"
+)
 reticulate::py_run_string("import synapseclient.operations")
-generateRdFiles(srcRootDir,
-                pyPkg = "synapseclient",
-                container = "synapseclient.operations",
-                functionFilter = .removeAsyncFunctionFilter,
-                keepContent = TRUE,
-                functionPrefix = "syn",
-                generateFunctionalInterface = TRUE,
-                )
-generateRdFiles(srcRootDir,
-                pyPkg = "synapseclient",
-                container = "synapseclient.models",
-                functionFilter = .removeAsyncFunctionFilter,
-                classFilter = .synapseModelClassFilter,
-                keepContent = TRUE,
-                functionPrefix = "syn",
-                generateFunctionalInterface = TRUE,
-                )
+generateRdFiles(
+    srcRootDir,
+    pyPkg = "synapseclient",
+    container = "synapseclient.operations",
+    functionFilter = .operationsFunctionNamesFilter,
+    keepContent = TRUE,
+    functionPrefix = "syn"
+)
+generateRdFiles(
+    srcRootDir,
+    pyPkg = "synapseclient",
+    container = "synapseclient.models",
+    functionFilter = .removeAsyncFunctionFilter,
+    classFilter = .synapseModelClassFilter,
+    keepContent = TRUE,
+    functionPrefix = "syn",
+    generateFunctionalInterface = TRUE,
+    functionNameMapping = .synapseClientModelsMapping()
+)

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -9,6 +9,12 @@ srcRootDir <- args[1]
 source(sprintf("%s/R/shared.R", srcRootDir))
 source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
 
+# Must be declared before any Python call below so reticulate's
+# uv-managed ephemeral environment resolves this requirement instead of
+# provisioning a fresh empty environment for this process (this script
+# runs as its own Rscript process, separate from installPythonClient.R).
+reticulate::py_require("synapseclient[pandas]==4.12")
+
 reticulate::py_run_string("import sys")
 reticulate::py_run_string(sprintf(
     "sys.path.append(\"%s\")",

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -17,17 +17,21 @@ generateRdFiles(srcRootDir,
                 container = "synapseclient.Synapse",
                 functionFilter = .synapseClassFunctionFilter,
                 functionPrefix = "syn")
-## all classes in synapseclient module
+reticulate::py_run_string("import synapseclient.operations")
 generateRdFiles(srcRootDir,
                 pyPkg = "synapseclient",
-                container = "synapseclient",
-                functionFilter = .removeAllFunctionsFunctionFilter,
-                classFilter = .synapseClientClassFilter,
-                keepContent = TRUE)
-# cherry pick Table function
+                container = "synapseclient.operations",
+                functionFilter = .removeAsyncFunctionFilter,
+                keepContent = TRUE,
+                functionPrefix = "syn",
+                generateFunctionalInterface = TRUE,
+                )
 generateRdFiles(srcRootDir,
                 pyPkg = "synapseclient",
-                container = "synapseclient.table",
-                functionFilter = .cherryPickTableFunctionFilter,
-                classFilter = .removeAllClassesClassFilter,
-                keepContent = TRUE)
+                container = "synapseclient.models",
+                functionFilter = .removeAsyncFunctionFilter,
+                classFilter = .synapseModelClassFilter,
+                keepContent = TRUE,
+                functionPrefix = "syn",
+                generateFunctionalInterface = TRUE,
+                )

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -20,7 +20,8 @@ generateRdFiles(
     pyPkg = "synapseclient",
     container = "synapseclient.Synapse",
     functionFilter = .synapseClassFunctionFilter,
-    functionPrefix = "syn"
+    functionPrefix = "syn",
+    functionNameMapping = .functionNameMappingSynapse()
 )
 reticulate::py_run_string("import synapseclient.operations")
 generateRdFiles(
@@ -40,5 +41,5 @@ generateRdFiles(
     keepContent = TRUE,
     functionPrefix = "syn",
     generateFunctionalInterface = TRUE,
-    functionNameMapping = .synapseClientModelsMapping()
+    functionNameMapping = .functionNameMappingSynapseclientModels()
 )

--- a/tools/createRdFiles.R
+++ b/tools/createRdFiles.R
@@ -4,8 +4,6 @@ library("rjson")
 args <- commandArgs(TRUE)
 srcRootDir <- args[1]
 
-# 'source' some functions shared with the synapser package
-# to get omitFunctions and omitClasses
 source(sprintf("%s/R/shared.R", srcRootDir))
 source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
 
@@ -13,7 +11,9 @@ source(sprintf("%s/R/PythonPkgWrapperUtils.R", srcRootDir))
 # uv-managed ephemeral environment resolves this requirement instead of
 # provisioning a fresh empty environment for this process (this script
 # runs as its own Rscript process, separate from installPythonClient.R).
-reticulate::py_require("synapseclient[pandas]==4.12")
+reticulate::py_require(
+    paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep = "")
+)
 
 reticulate::py_run_string("import sys")
 reticulate::py_run_string(sprintf(

--- a/tools/installPythonClient.R
+++ b/tools/installPythonClient.R
@@ -1,25 +1,31 @@
 # R script to install the Synapse Python client
 # The script itself is written in Python.  This is simply a wrapper to call it
 # via the rWithPython package
-#
+# This script runs during configure, before synapser itself is installed.
 # Author: bhoff
 ###############################################################################
 
-PYTHON_CLIENT_VERSION <- '4.12'
-
 args <- commandArgs(trailingOnly = TRUE)
-baseDir<-args[1]
+baseDir <- args[1]
 
 if (is.null(baseDir) || is.na(baseDir) || !file.exists(baseDir)) {
   stop(paste("baseDir", baseDir, "is invalid"))
 }
+
+source(file.path(baseDir, "R", "shared.R"))
 # Must be declared before any Python call (including py_config() below)
 # so reticulate's uv-managed ephemeral environment resolves this
 # requirement instead of provisioning a fresh empty environment.
-reticulate::py_require(c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep="")))
+reticulate::py_require(c(paste(
+  "synapseclient[pandas]==",
+  PYTHON_CLIENT_VERSION,
+  sep = ""
+)))
 
 print("*** Using Python Configuration:")
 reticulate::py_config()
 reticulate::py_run_string("import sys")
-reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(baseDir, "inst", "python")))
-
+reticulate::py_run_string(sprintf(
+  "sys.path.append(\"%s\")",
+  file.path(baseDir, "inst", "python")
+))

--- a/tools/installPythonClient.R
+++ b/tools/installPythonClient.R
@@ -13,8 +13,13 @@ baseDir<-args[1]
 if (is.null(baseDir) || is.na(baseDir) || !file.exists(baseDir)) {
   stop(paste("baseDir", baseDir, "is invalid"))
 }
+# Must be declared before any Python call (including py_config() below)
+# so reticulate's uv-managed ephemeral environment resolves this
+# requirement instead of provisioning a fresh empty environment.
+reticulate::py_require(c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep="")))
+
 print("*** Using Python Configuration:")
 reticulate::py_config()
 reticulate::py_run_string("import sys")
 reticulate::py_run_string(sprintf("sys.path.append(\"%s\")", file.path(baseDir, "inst", "python")))
-reticulate::py_install(c(paste("synapseclient[pandas]==", PYTHON_CLIENT_VERSION, sep="")), pip=T)
+

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -1,0 +1,172 @@
+---
+title: "Data Upload, Download, and Delete"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Data Upload, Download, and Delete}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+## Overview
+
+This vignette demonstrates how to upload, download, and delete data using `synapser`.
+
+**Note on integer parameters:** R's bare numeric literals (e.g. `1`) are
+doubles. Parameters that the Synapse API expects as integers — such as
+`version_number` and `version` — must be written with the `L` suffix
+(e.g. `1L`) to pass a true integer to Python. Passing `1` instead of `1L`
+may cause unexpected behavior or an API error.
+
+
+## Key differences from the legacy API:
+
+| Task | Legacy | New pipe UI |
+|---|---|---|
+| Store an entity | `synStore(obj, ...)` | `File(...) |> synStore(file_options, container_options, ...)` or `synStore(entity = File(...), parent, file_options, container_options, ...)`|
+| Suppress new version | `synStore(obj, forceVersion = FALSE)` | `File(...) |> synStore()` |
+| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(synapse_id) |> (\(x) {x$version_label <- "2"; x})() |> synStore()` |
+| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(synapse_id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
+| Access entity ID | `entity$properties$id` | `entity$id` |
+| Get an entity | `synGet(entity, ...)` | `File(...) |> synGet(file_options, ...)` or `synGet(synapse_id, file_options, ...)` |
+| Get a specific version | `synGet(entity, version = 1)` | `File(id) |> synGet(version_number = 1L)` or `synGet(synapse_id, version_number = 1L)` |
+| Skip file download | `synGet(entity, downloadFile = FALSE)` | `File(...) |> synGet(file_options = FileOptions(download_file = FALSE))` or `synGet(synapse_id, file_options = FileOptions(download_file = FALSE))` |
+| Delete a version | `synDelete(obj, version = 1)` | `File(...) |> synDelete(version = 1L,  version_only = TRUE)` or `synDelete(entity, version = 1L,  version_only = TRUE)` |
+
+## Load the package
+```{r eval=FALSE}
+library(synapser)
+```
+
+## Login
+
+```{r eval=FALSE}
+synLogin()
+```
+
+Credentials are read from `~/.synapseConfig` or the `SYNAPSE_AUTH_TOKEN`
+environment variable. See the
+[Managing Credentials](manageSynapseCredentials.html) vignette for setup
+details.
+
+## Create a Project
+
+```{r eval=FALSE}
+project <- Project(
+  name = paste0(
+    "My uniquely named project about Alzheimer's Disease ",
+    paste(sample(c(letters, LETTERS, 0:9), 8, replace = TRUE), collapse = "")
+  )
+) |> synStore()
+cat("Created project:", project$id, "\n")
+```
+
+`synStore()` returns the stored entity with the assigned Synapse ID in
+`project$id`. In the new models API, IDs are accessed directly on the object
+(`project$id`) rather than through `project$properties$id`.
+
+## Create a Folder
+
+Create a folder inside the project:
+
+```{r eval=FALSE}
+data_folder <- Folder(
+  name = "single_cell_RNAseq_batch_1",
+  parent_id = project$id
+) |> synStore()
+cat("Created folder:", data_folder$id, "\n")
+```
+
+## Upload a File
+
+Create a local file and upload it to the folder. 
+
+```{r eval=FALSE}
+# Create a temporary file with some content
+tmp <- tempfile(fileext = ".txt")
+writeLines(c("sample", "data"), tmp)
+
+file <- File(
+  path = tmp,
+  parent_id = data_folder$id
+) |> synStore()
+cat("Uploaded file:", file$id, "\n")
+```
+Storing the same file path as an existing version does not create a duplicate. Synapse detects unchanged content by MD5.
+
+## Version the file
+
+```{r eval=FALSE}
+file <- synGet(synapse_id = file$id) |>
+  (\(x) {
+    x$version_label   <- "2"
+    x$version_comment <- "Added version 2"
+    x
+  })() |>
+  synStore()
+```
+
+## Add, Update and Remove Annotations
+
+Use `synStore()` to add, update and remove annotations. To modify annotations, you don't have to download the file. 
+### Add annotations to a file
+```{r eval=FALSE}
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
+file$annotations <- list(
+  assay = "RNA-seq", fileType = "csv", dataStage = "processed"
+)
+file <- file |> synStore()
+```
+
+### Update annotations of a file
+```{r eval=FALSE}
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
+file$annotations <- append(file$annotations, list(new = "new_annotation"))
+file <- file |> synStore()
+```
+
+### Remove annotations of a file
+```{r eval=FALSE}
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
+file$annotations <- list()
+file <- file |> synStore()
+```
+
+## Download a File
+
+Retrieve a file by its Synapse ID. The file is downloaded to the local cache `.synapseCache` by default. 
+To set a download path, use `FileOptions(download_location = "/path/to/downloads/")` in the `file_options` parameter. 
+
+```{r eval=FALSE}
+downloaded_file <- synGet(
+  file$id,
+  file_options = FileOptions(download_location = "/path/to/downloads/")
+)
+cat("Downloaded to:", downloaded_file$path, "\n")
+```
+
+## Download a Specific Version
+
+Use `version_number` to pin to a particular version:
+
+```{r eval=FALSE}
+version_1 <- synGet(file$id, version_number = 1L)
+cat("Version 1 path:", version_1$path, "\n")
+```
+
+## Clean Up
+
+Delete the project and all its contents when done:
+
+```{r eval=FALSE}
+synDelete(project)
+```


### PR DESCRIPTION
**Problem**
1. An **Instance-first with Pipe** interface needs to be implemented (see the [design doc](https://sagebionetworks.jira.com/wiki/spaces/SYNR/pages/4725342282/R+Client+User+Interface+Design)).
2. Most legacy Synapse functions need to be deprecated, as their functionality has either been fully deprecated or replaced by model classes.
3. The new SYNPY models interface has not yet been exposed through the R client.
4. The new operations functions still need to be added.
5. The previous filtering strategy relied on denylists (`.classesToSkip`, `.methodsToOmit`), which proved to be fragile. The original deprecation logic only covered functions decorated with `Deprecation`, but we also need to handle functions marked with `TODO` comments. In addition, any new class or method added to `synapseclient` required manual updates to the exclusion lists; otherwise, it could be unintentionally exposed in the R API.
6. Beyond the API design challenges, `pyPkgInfo.py`—the Python introspection layer used to discover class methods—could not properly handle several modern `synapseclient` design patterns:

   * Methods implemented on Protocol mixin classes were not detected and were therefore silently omitted from the generated wrappers. In addition, docstrings defined on Protocol classes and mixins could not be extracted correctly, leading to missing documentation in the generated wrappers.
   * Methods wrapped with `async_to_sync` reported incorrect signatures and empty docstrings because introspection resolved the wrapper function rather than the underlying protocol method.
7.  Passing a bare 1 being translated by reticulate into a Python float that causing api data type error. 
 
**Solution**
  * **Instance-first with Pipe**
     * defineFunctionalClassMethod was rewritten to generate one public generic per verb (e.g. synStore, synGet, synDelete) backed by a private dispatch table (.functionalMethodDispatch). When a new (class, method) pair is registered, a class-specific closure is stored in the table under the key "<genericName>_<className>". The public generic inspects class(instance)[1] at call time and routes to the correct closure
     * Constructors now tag returned Python objects with an R S3 class so the generic can dispatch correctly. 
     * Static methods (isStatic = TRUE) are handled separately — they resolve the Python class at call time and call the method directly without an instance. 
     * The public generic emits a helpful error if called with no argument or with an unregistered class.

```
File(...) |> synStore()     # routes to synStore_File worker
Project(...) |> synStore()  # routes to synStore_Project worker

```

  * **Allowlist-based filtering**
Filtering was flipped from exclusion-based to inclusion-based:

    * `.synapseClassMethodsToInclude` replaces the old deprecation/denylist check for Synapse class methods
    * `.modelClassMethodsToInclude` replaces `.classesToSkip` for model classes, only explicitly listed classes are exposed
    * `.operationsFunctionNamesFilter` replaces the broad async-strip filter for `synapseclient.operations`
This makes the exposed API surface explicit and stable; new upstream classes or methods do not accidentally appear.

  * **Python introspection overhaul**
    * Enhanced Python helper functions to detect if a method is inherited from a Protocol (PEP 544) and to extract docstrings from protocol classes or mixins, ensuring that R wrappers have accurate and complete documentation even for protocol-based methods. Specifically: 
      * is_method_from_protocol: detects methods inherited from Protocol mixin classes by walking the MRO, enabling getClassInfo to include them
      * is_async_to_sync_wrapper / find_protocol_method_info: when a method is an async_to_sync wrapper, the correct signature and docstring are resolved from the Protocol definition rather than the wrapper
      * getCleanedDoc extended to search Protocol class hierarchies for docstrings that async_to_sync wrappers obscure
      * _has_deprecation_todo: scans source lines for # TODO: Deprecate method comments and surfaces a deprecated_todo field so filters can act on it
      * Removed annotationsModifier and the synapseclient.annotations.Annotations import — synapseclient 4.x returns plain dicts from annotation methods, so the conversion layer is no longer needed.
      * getEnumInfo extracts per-attribute inline docstrings via AST parsing

  * **R wrapper generation improvements**

       * Refactored the R wrapper generation logic to explicitly include or omit specific methods and classes from `synapseclient`, `synapseclient.operations`, and `synapseclient.models`, introducing filters like `.synapseClassMethodsToInclude`, `.modelClassMethodsToInclude`, `.modelClassMethodsToOmit`, and `.operationsFunctionNames`. This ensures only relevant, non-deprecated, and synchronous methods are exposed to R users.
       * Updated the wrapper registration in `zzz.R` to use the new filters, expose only synchronous functions, and provide explicit function name mapping for model classes. Now, wrappers for `synapseclient.operations` and `synapseclient.models` are generated with fine-grained control, and functional interfaces are enabled for models.
confirmed sufficient.

   * **Codebase cleanup and simplification**

       * Removed redundant or problematic R S4 method/class definitions for table operations and CSV file handling, simplifying overloads and reducing the risk of infinite recursion or binding errors. 
       * Cleaned up the Python gateway by removing unused imports and the unnecessary `annotationsModifier`
       * Refactor `removeNulls`

**Testing**
Unit tests were added for PythonPkgWrapperUtils.R and shared.R
1. test_PythonPkgWrapperUtils.R (new): covers capitalizeFirstLetter, snakeToCamel, addPrefix, removeNulls, applyFunctionNameMapping, defineFunctionalClassMethod dispatch table registration, generic routing by class, static method paths, empty-argument and unregistered-class error paths, and defineFunction/defineClassMethod formal construction
3. test_shared.R: covers the allowlist filters (.synapseClassFunctionFilter, .synapseModelClassFilter, .operationsFunctionNamesFilter) to verify only expected classes/methods pass through, and that async methods, internal helpers, and unlisted classes are excluded

This pull request introduces significant improvements to the R and Python interoperability layer for the Synapse client, focusing on more precise control over which Python classes and methods are exposed to R, better handling of protocol-based methods and documentation, and codebase clean-up. 




