### PR TITLE
[SYNR-1586, SYNR-1587, SYNR-1574]add data upload download vignette for new interface

### DIFF
--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -10,7 +10,7 @@ vignette: >
 
 ## Overview
 
-This instruction demonstrates how to upload, download, and delete data using `synapser`.
+This vignette demonstrates how to upload, download, and delete data using `synapser`.
 
 
 Key differences from the legacy API:
@@ -19,11 +19,11 @@ Key differences from the legacy API:
 |---|---|---|
 | Store an entity | `synStore(obj, ...)` | `File(...) |> synStore(file_options, container_options, ...)` or `synStore(entity = File(...), parent, file_options, container_options, ...)`|
 | Suppress new version | `synStore(obj, forceVersion = FALSE)` | `File(...) |> synStore()` |
-| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(id) |> (\(x) {x$version_label <- "2"; x})() |> synStore()` |
-| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
+| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(synapse_id) |> (\(x) {x$version_label <- "2"; x})() |> synStore()` |
+| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(synapse_id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
 | Access entity ID | `entity$properties$id` | `entity$id` |
 | Get an entity | `synGet(entity, ...)` | `File(...) |> synGet(file_options, ...)` or `synGet(synapse_id, file_options, ...)` |
-| Get a specific version | `synGet(entity, version = 1)` | `File(id, version_label = 1) |> synGet()` or `File(id) |> synGet(version_number = 1)` or `synGet(synapse_id, version_number = 1)` |
+| Get a specific version | `synGet(entity, version = 1)` | `File(id) |> synGet(version_number = 1)` or `synGet(synapse_id, version_number = 1)` |
 | Skip file download | `synGet(entity, downloadFile = FALSE)` | `File(...) |> synGet(file_options = FileOptions(download_file = FALSE))` or `synGet(synapse_id, file_options = FileOptions(download_file = FALSE))` |
 | Delete a version | `synDelete(obj, version = 1)` | `File(...) |> synDelete(version = 1,  version_only = TRUE)` or `synDelete(entity, version = 1,  version_only = TRUE)` |
 
@@ -46,7 +46,9 @@ details.
 ## Create a Project
 
 ```{r eval=FALSE}
-project <- Project(name="My uniquely named project about Alzheimer's Disease_danlu_r") |> synStore()
+project <- Project(
+  name = "My uniquely named project about Alzheimer's Disease"
+) |> synStore()
 cat("Created project:", project$id, "\n")
 ```
 
@@ -59,7 +61,10 @@ cat("Created project:", project$id, "\n")
 Create a folder inside the project:
 
 ```{r eval=FALSE}
-data_folder <- Folder(name = "single_cell_RNAseq_batch_1", parent_id = project$id) |> synStore()
+data_folder <- Folder(
+  name = "single_cell_RNAseq_batch_1",
+  parent_id = project$id
+) |> synStore()
 cat("Created folder:", data_folder$id, "\n")
 ```
 
@@ -68,7 +73,10 @@ cat("Created folder:", data_folder$id, "\n")
 Create a local file and upload it to the folder. 
 
 ```{r eval=FALSE}
-file <- File(path = "~/my_ad_project/biospecimen_experiment_1/fileA.txt", parent_id = data_folder$id) |> synStore()
+file <- File(
+  path = "~/my_ad_project/biospecimen_experiment_1/fileA.txt",
+  parent_id = data_folder$id
+) |> synStore()
 cat("Uploaded file:", file$id, "\n")
 ```
 Storing the same file path as an existing version does not create a duplicate. Synapse detects unchanged content by MD5.
@@ -77,29 +85,34 @@ Storing the same file path as an existing version does not create a duplicate. S
 
 ```{r eval=FALSE}
 file <- synGet(synapse_id = file$id) |>
-    (\(x) {
-      x$version_label   <- "2"
-      x$version_comment <- "Added version 2"
-      x
-    })() |>
-    synStore()
+  (\(x) {
+    x$version_label   <- "2"
+    x$version_comment <- "Added version 2"
+    x
+  })() |>
+  synStore()
 ```
 
 ## Add or Update Annotations
 
 Use `synStore()` to add or update annotations.
 ```{r eval=FALSE}
-file$annotations  <- list(assay = "RNA-seq", fileType = "csv", dataStage = "processed")
+file$annotations <- list(
+  assay = "RNA-seq", fileType = "csv", dataStage = "processed"
+)
 file <- file |> synStore()
 ```
 
 ## Download a File
 
 Retrieve a file by its Synapse ID. The file is downloaded to the local cache `.synapseCache` by default. 
-To set a download path, use `FileOptions(download_location = "...")` in the `file_options` parameter. 
+To set a download path, use `FileOptions(download_location = "my_folder/my_file.txt")` in the `file_options` parameter. 
 
 ```{r eval=FALSE}
-downloaded_file <- synGet(file$id, file_options = FileOptions(download_location = "..."))
+downloaded_file <- synGet(
+  file$id,
+  file_options = FileOptions(download_location = "my_folder/my_file.txt")
+)
 cat("Downloaded to:", downloaded_file$path, "\n")
 ```
 

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -1,0 +1,121 @@
+---
+title: "Data Upload, Download, and Delete"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Data Upload, Download, and Delete}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+## Overview
+
+This instruction demonstrates how to upload, download, and delete data using `synapser`.
+
+
+Key differences from the legacy API:
+
+| Task | Legacy | New pipe UI |
+|---|---|---|
+| Store an entity | `synStore(obj, ...)` | `File(...) |> synStore(file_options, container_options, ...)` or `synStore(entity = File(...), parent, file_options, container_options, ...)`|
+| Suppress new version | `synStore(obj, forceVersion = FALSE)` | `File(...) |> synStore()` |
+| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(id) |> (\(x) {x$version_label <- "2"; x})() |> synStore()` |
+| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
+| Access entity ID | `entity$properties$id` | `entity$id` |
+| Get an entity | `synGet(entity, ...)` | `File(...) |> synGet(file_options, ...)` or `synGet(synapse_id, file_options, ...)` |
+| Get a specific version | `synGet(entity, version = 1)` | `File(id, version_label = 1) |> synGet()` or `File(id) |> synGet(version_number = 1)` or `synGet(synapse_id, version_number = 1)` |
+| Skip file download | `synGet(entity, downloadFile = FALSE)` | `File(...) |> synGet(file_options = FileOptions(download_file = FALSE))` or `synGet(synapse_id, file_options = FileOptions(download_file = FALSE))` |
+| Delete a version | `synDelete(obj, version = 1)` | `File(...) |> synDelete(version = 1,  version_only = TRUE)` or `synDelete(entity, version = 1,  version_only = TRUE)` |
+
+## Load the package
+```{r eval=FALSE}
+library(synapser)
+```
+
+## Login
+
+```{r eval=FALSE}
+synLogin()
+```
+
+Credentials are read from `~/.synapseConfig` or the `SYNAPSE_AUTH_TOKEN`
+environment variable. See the
+[Managing Credentials](manageSynapseCredentials.html) vignette for setup
+details.
+
+## Create a Project
+
+```{r eval=FALSE}
+project <- Project(name="My uniquely named project about Alzheimer's Disease_danlu_r") |> synStore()
+cat("Created project:", project$id, "\n")
+```
+
+`synStore()` returns the stored entity with the assigned Synapse ID in
+`project$id`. In the new models API, IDs are accessed directly on the object
+(`project$id`) rather than through `project$properties$id`.
+
+## Create a Folder
+
+Create a folder inside the project:
+
+```{r eval=FALSE}
+data_folder <- Folder(name = "single_cell_RNAseq_batch_1", parent_id = project$id) |> synStore()
+cat("Created folder:", data_folder$id, "\n")
+```
+
+## Upload a File
+
+Create a local file and upload it to the folder. 
+
+```{r eval=FALSE}
+file <- File(path = "~/my_ad_project/biospecimen_experiment_1/fileA.txt", parent_id = data_folder$id) |> synStore()
+cat("Uploaded file:", file$id, "\n")
+```
+Storing the same file path as an existing version does not create a duplicate. Synapse detects unchanged content by MD5.
+
+## Version the file
+
+```{r eval=FALSE}
+file <- synGet(synapse_id = file$id) |>
+    (\(x) {
+      x$version_label   <- "2"
+      x$version_comment <- "Added version 2"
+      x
+    })() |>
+    synStore()
+```
+
+## Add or Update Annotations
+
+Use `synStore()` to add or update annotations.
+```{r eval=FALSE}
+file$annotations  <- list(assay = "RNA-seq", fileType = "csv", dataStage = "processed")
+file <- file |> synStore()
+```
+
+## Download a File
+
+Retrieve a file by its Synapse ID. The file is downloaded to the local cache `.synapseCache` by default. 
+To set a download path, use `FileOptions(download_location = "...")` in the `file_options` parameter. 
+
+```{r eval=FALSE}
+downloaded_file <- synGet(file$id, file_options = FileOptions(download_location = "..."))
+cat("Downloaded to:", downloaded_file$path, "\n")
+```
+
+## Download a Specific Version
+
+Use `version_number` to pin to a particular version:
+
+```{r eval=FALSE}
+version_1 <- synGet(file$id, version_number = 1)
+cat("Version 1 path:", version_1$path, "\n")
+```
+
+## Clean Up
+
+Delete the project and all its contents when done:
+
+```{r eval=FALSE}
+synDelete(project)
+```

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -53,7 +53,10 @@ details.
 
 ```{r eval=FALSE}
 project <- Project(
-  name = "My uniquely named project about Alzheimer's Disease"
+  name = paste0(
+    "My uniquely named project about Alzheimer's Disease ",
+    paste(sample(c(letters, LETTERS, 0:9), 8, replace = TRUE), collapse = "")
+  )
 ) |> synStore()
 cat("Created project:", project$id, "\n")
 ```
@@ -79,8 +82,12 @@ cat("Created folder:", data_folder$id, "\n")
 Create a local file and upload it to the folder. 
 
 ```{r eval=FALSE}
+# Create a temporary file with some content
+tmp <- tempfile(fileext = ".txt")
+writeLines(c("sample", "data"), tmp)
+
 file <- File(
-  path = "~/my_ad_project/biospecimen_experiment_1/fileA.txt",
+  path = tmp,
   parent_id = data_folder$id
 ) |> synStore()
 cat("Uploaded file:", file$id, "\n")

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -116,14 +116,20 @@ file <- file |> synStore()
 
 ### Update annotations of a file
 ```{r eval=FALSE}
-file <- synGet(synapse_id = file$id, file_options = FileOptions(download_file = FALSE))
-file$annotations <- append(file$annotations, list(new = 'new_annotation'))
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
+file$annotations <- append(file$annotations, list(new = "new_annotation"))
 file <- file |> synStore()
 ```
 
 ### Remove annotations of a file
 ```{r eval=FALSE}
-file <- synGet(synapse_id = file$id, file_options = FileOptions(download_file = FALSE))
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
 file$annotations <- list()
 file <- file |> synStore()
 ```

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -19,7 +19,7 @@ doubles. Parameters that the Synapse API expects as integers — such as
 may cause unexpected behavior or an API error.
 
 
-Key differences from the legacy API:
+## Key differences from the legacy API:
 
 | Task | Legacy | New pipe UI |
 |---|---|---|
@@ -99,25 +99,44 @@ file <- synGet(synapse_id = file$id) |>
   synStore()
 ```
 
-## Add or Update Annotations
+## Add, Update and Remove Annotations
 
-Use `synStore()` to add or update annotations.
+Use `synStore()` to add, update and remove annotations. To modify annotations, you don't have to download the file. 
+### Add annotations to a file
 ```{r eval=FALSE}
+file <- synGet(
+  synapse_id = file$id,
+  file_options = FileOptions(download_file = FALSE)
+)
 file$annotations <- list(
   assay = "RNA-seq", fileType = "csv", dataStage = "processed"
 )
 file <- file |> synStore()
 ```
 
+### Update annotations of a file
+```{r eval=FALSE}
+file <- synGet(synapse_id = file$id, file_options = FileOptions(download_file = FALSE))
+file$annotations <- append(file$annotations, list(new = 'new_annotation'))
+file <- file |> synStore()
+```
+
+### Remove annotations of a file
+```{r eval=FALSE}
+file <- synGet(synapse_id = file$id, file_options = FileOptions(download_file = FALSE))
+file$annotations <- list()
+file <- file |> synStore()
+```
+
 ## Download a File
 
 Retrieve a file by its Synapse ID. The file is downloaded to the local cache `.synapseCache` by default. 
-To set a download path, use `FileOptions(download_location = "my_folder/my_file.txt")` in the `file_options` parameter. 
+To set a download path, use `FileOptions(download_location = "/path/to/downloads/")` in the `file_options` parameter. 
 
 ```{r eval=FALSE}
 downloaded_file <- synGet(
   file$id,
-  file_options = FileOptions(download_location = "my_folder/my_file.txt")
+  file_options = FileOptions(download_location = "/path/to/downloads/")
 )
 cat("Downloaded to:", downloaded_file$path, "\n")
 ```

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -12,6 +12,12 @@ vignette: >
 
 This vignette demonstrates how to upload, download, and delete data using `synapser`.
 
+**Note on integer parameters:** R's bare numeric literals (e.g. `1`) are
+doubles. Parameters that the Synapse API expects as integers — such as
+`version_number` and `version` — must be written with the `L` suffix
+(e.g. `1L`) to pass a true integer to Python. Passing `1` instead of `1L`
+may cause unexpected behavior or an API error.
+
 
 Key differences from the legacy API:
 
@@ -23,9 +29,9 @@ Key differences from the legacy API:
 | Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(synapse_id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
 | Access entity ID | `entity$properties$id` | `entity$id` |
 | Get an entity | `synGet(entity, ...)` | `File(...) |> synGet(file_options, ...)` or `synGet(synapse_id, file_options, ...)` |
-| Get a specific version | `synGet(entity, version = 1)` | `File(id) |> synGet(version_number = 1)` or `synGet(synapse_id, version_number = 1)` |
+| Get a specific version | `synGet(entity, version = 1)` | `File(id) |> synGet(version_number = 1L)` or `synGet(synapse_id, version_number = 1L)` |
 | Skip file download | `synGet(entity, downloadFile = FALSE)` | `File(...) |> synGet(file_options = FileOptions(download_file = FALSE))` or `synGet(synapse_id, file_options = FileOptions(download_file = FALSE))` |
-| Delete a version | `synDelete(obj, version = 1)` | `File(...) |> synDelete(version = 1,  version_only = TRUE)` or `synDelete(entity, version = 1,  version_only = TRUE)` |
+| Delete a version | `synDelete(obj, version = 1)` | `File(...) |> synDelete(version = 1L,  version_only = TRUE)` or `synDelete(entity, version = 1L,  version_only = TRUE)` |
 
 ## Load the package
 ```{r eval=FALSE}
@@ -121,7 +127,7 @@ cat("Downloaded to:", downloaded_file$path, "\n")
 Use `version_number` to pin to a particular version:
 
 ```{r eval=FALSE}
-version_1 <- synGet(file$id, version_number = 1)
+version_1 <- synGet(file$id, version_number = 1L)
 cat("Version 1 path:", version_1$path, "\n")
 ```
 


### PR DESCRIPTION
# **Problem:**

The data upload and download instruction should be updated due to interface changes. 

# **Solution:**
* Added a new vignette, `vignettes/data_upload_download.Rmd`, that documents how to upload, download, and delete data with `synapser`, including code examples for each step.
* Included a comparison table outlining key differences between the legacy API and the new pipe-based interface for common tasks such as storing entities, suppressing new versions, setting version labels, tracking provenance, and deleting versions.
* Provided detailed, step-by-step examples for creating projects, folders, uploading files, versioning, annotating, downloading files (including specific versions), and cleaning up entities.


**This vignette will be updated iteratively.** 

# **Testing:**

The vignette is knitted successfully.
<img width="1033" height="1013" alt="Screenshot 2026-06-15 at 10 58 51 AM" src="https://github.com/user-attachments/assets/21a63927-b159-43fd-a9f3-476a144c4b23" />
