### PR TITLE
[SYNR-1604] add set properties helper function

### DIFF
--- a/R/synSetProperties.R
+++ b/R/synSetProperties.R
@@ -1,3 +1,13 @@
+#' @title Set properties of an entity
+#' @description Set properties of an entity. When duplicate properties are provided, the first one will be used.
+#' @param entity The entity to set properties of
+#' @param ... The properties to set
+#' @return The entity with the properties set.
+#' @examples
+#' \dontrun{
+#' synSetProperties(entity, annotations = list(key = "value"))
+#' synSetProperties(entity, name = "new name", annotations = list(key = "value", key2 = "value2"))
+#' }
 synSetProperties <- function(entity, ...) {
   props <- list(...)
   if (length(props) == 0) {

--- a/R/synSetProperties.R
+++ b/R/synSetProperties.R
@@ -1,0 +1,23 @@
+synSetProperties <- function(entity, ...) {
+  props <- list(...)
+  if (length(props) == 0) {
+    return(entity)
+  }
+  if (is.null(names(props)) || any(names(props) == "")) {
+    stop(
+      "All arguments to synSetProperties must be named, e.g. annotations = list(...)"
+    )
+  }
+  valid_props <- names(entity$`__dataclass_fields__`)
+  invalid <- setdiff(names(props), valid_props)
+  if (length(invalid) > 0) {
+    stop(sprintf(
+      "The following are not valid attributes of this entity: %s",
+      paste(invalid, collapse = ", ")
+    ))
+  }
+  for (prop in names(props)) {
+    entity[[prop]] <- props[[prop]]
+  }
+  return(entity)
+}

--- a/man/synSetProperties.Rd
+++ b/man/synSetProperties.Rd
@@ -7,6 +7,7 @@ object before storing it. Returns the modified entity so it can be chained with
 \code{\link{synStore}} via the pipe operator.
 All provided properties must be named arguments and must correspond to valid attributes of the entity. 
 If any property is unnamed or is not a valid attribute, an error will be raised.
+If duplicate properties are provided, the first one will be used.
 }
 \usage{
 synSetProperties(entity, ...)

--- a/man/synSetProperties.Rd
+++ b/man/synSetProperties.Rd
@@ -1,0 +1,40 @@
+\name{synSetProperties}
+\alias{synSetProperties}
+\title{synSetProperties}
+\description{
+A pipe-friendly helper to set one or more named properties on a Synapse entity
+object before storing it. Returns the modified entity so it can be chained with
+\code{\link{synStore}} via the pipe operator.
+All provided properties must be named arguments and must correspond to valid attributes of the entity. 
+If any property is unnamed or is not a valid attribute, an error will be raised.
+}
+\usage{
+synSetProperties(entity, ...)
+}
+\arguments{
+\item{entity}{A Synapse entity object (e.g. File, Folder, Project, Table).}
+\item{...}{Named property-value pairs to set on the entity. Common properties
+  include \code{annotations} (a named list), \code{name} (string), and \code{description} (string), etc.}
+}
+\value{
+The entity with the specified properties updated.
+\code{\link{synStore}}.
+Throws an error if any property is unnamed or is not a valid attribute.
+}
+\examples{
+\dontrun{
+# Set annotations before storing
+synGet("syn123") |>
+  synSetProperties(annotations = list(foo="bar", baz=1)) |>
+  synStore()
+
+# Set multiple properties at once
+synGet("syn123") |>
+  synSetProperties(
+    name        = "updated name",
+    description = "updated description",
+    annotations = list(foo = "bar")
+  ) |>
+  synStore()
+}
+}

--- a/tests/testthat/test_synSetProperties.R
+++ b/tests/testthat/test_synSetProperties.R
@@ -1,0 +1,113 @@
+# One way to run the test is using devtools::test(filter = "synSetProperties")
+# from the synapser package directory.
+context("unit tests for synSetProperties")
+
+# Creates a mock entity environment whose __dataclass_fields__ mirrors a Python dataclass.
+mock_entity <- function(...) {
+  fields <- list(...)
+  e <- list2env(fields)
+  e$`__dataclass_fields__` <- setNames(
+    vector("list", length(fields)),
+    names(fields)
+  )
+  e
+}
+
+# --- Basic behaviour ---
+
+test_that("synSetProperties with no extra args returns entity unchanged", {
+  entity <- mock_entity(name = "original")
+  result <- synSetProperties(entity)
+  expect_equal(result$name, "original")
+})
+
+test_that("synSetProperties sets a single property on an entity", {
+  entity <- mock_entity(name = "original", annotations = list())
+  result <- synSetProperties(entity, name = "updated")
+  expect_equal(result$name, "updated")
+  expect_equal(result$annotations, list())
+})
+
+test_that("synSetProperties sets multiple properties at once", {
+  entity <- mock_entity(name = "original", annotations = list())
+  result <- synSetProperties(
+    entity,
+    name = "new name",
+    annotations = list(tissue = "brain", n = 42L)
+  )
+  expect_equal(result$name, "new name")
+  expect_equal(result$annotations, list(tissue = "brain", n = 42L))
+})
+
+test_that("synSetProperties supports setting a valid property to NULL", {
+  entity <- mock_entity(name = "original", annotations = list(a = 1))
+  result <- synSetProperties(entity, annotations = NULL)
+  expect_true(exists("annotations", envir = result, inherits = FALSE))
+  expect_null(result$annotations)
+})
+
+test_that("synSetProperties is pipe-friendly", {
+  entity <- mock_entity(name = "original")
+  result <- entity |> synSetProperties(name = "piped")
+  expect_equal(result$name, "piped")
+})
+
+# --- Validation errors ---
+
+test_that("synSetProperties errors when an argument is unnamed", {
+  entity <- mock_entity()
+  expect_error(
+    synSetProperties(entity, list(a = 1)),
+    "All arguments to synSetProperties must be named, e.g. annotations = list(...)"
+  )
+})
+
+test_that("synSetProperties errors when arguments are mixed named and unnamed", {
+  entity <- mock_entity(name = "original")
+  expect_error(
+    synSetProperties(entity, "oops", name = "updated"),
+    "All arguments to synSetProperties must be named, e.g. annotations = list(...)"
+  )
+})
+
+test_that("synSetProperties errors on a property not present on the entity", {
+  entity <- mock_entity(name = "foo")
+  expect_error(
+    synSetProperties(
+      entity,
+      annotations = list(key = "value"),
+      description = "new description"
+    ),
+    "The following are not valid attributes of this entity: annotations, description"
+  )
+})
+
+test_that("synSetProperties does not partially update when any property is invalid", {
+  entity <- mock_entity(name = "original", annotations = list())
+  expect_error(
+    synSetProperties(entity, name = "updated", notAProp = 123),
+    "The following are not valid attributes of this entity: notAProp"
+  )
+  expect_equal(entity$name, "original")
+  expect_equal(entity$annotations, list())
+})
+
+test_that("synSetProperties errors when entity dataclass fields are missing", {
+  entity <- mock_entity(name = "original")
+  rm(list = "__dataclass_fields__", envir = entity)
+  expect_error(
+    synSetProperties(entity, name = "updated"),
+    "The following are not valid attributes of this entity: name"
+  )
+})
+
+# --- Edge cases ---
+
+test_that("synSetProperties keeps first value for duplicate names via do.call", {
+  entity <- mock_entity(name = "original")
+  result <- do.call(
+    synSetProperties,
+    list(entity = entity, name = "first", name = "second")
+  )
+  expect_equal(result$name, "first")
+})

--- a/vignettes/data_upload_download.Rmd
+++ b/vignettes/data_upload_download.Rmd
@@ -18,15 +18,14 @@ doubles. Parameters that the Synapse API expects as integers — such as
 (e.g. `1L`) to pass a true integer to Python. Passing `1` instead of `1L`
 may cause unexpected behavior or an API error.
 
-
 ## Key differences from the legacy API:
 
 | Task | Legacy | New pipe UI |
 |---|---|---|
 | Store an entity | `synStore(obj, ...)` | `File(...) |> synStore(file_options, container_options, ...)` or `synStore(entity = File(...), parent, file_options, container_options, ...)`|
 | Suppress new version | `synStore(obj, forceVersion = FALSE)` | `File(...) |> synStore()` |
-| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(synapse_id) |> (\(x) {x$version_label <- "2"; x})() |> synStore()` |
-| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(synapse_id) |> (\(x) {x$activity <- Activity(used = list("syn123"), executed = list("syn456")); x})() |> synStore()` |
+| Set version label | `synStore(obj, versionLabel = "2")` | `synGet(synapse_id) |> synSetProperties(version_label = "2") |> synStore()` |
+| Track provenance | `synStore(obj, used = "syn123", executed = "syn456")` | `synGet(synapse_id) |> synSetProperties(activity = Activity(used = list("syn123"), executed = list("syn456"))) |> synStore()`|
 | Access entity ID | `entity$properties$id` | `entity$id` |
 | Get an entity | `synGet(entity, ...)` | `File(...) |> synGet(file_options, ...)` or `synGet(synapse_id, file_options, ...)` |
 | Get a specific version | `synGet(entity, version = 1)` | `File(id) |> synGet(version_number = 1L)` or `synGet(synapse_id, version_number = 1L)` |
@@ -98,11 +97,10 @@ Storing the same file path as an existing version does not create a duplicate. S
 
 ```{r eval=FALSE}
 file <- synGet(synapse_id = file$id) |>
-  (\(x) {
-    x$version_label   <- "2"
-    x$version_comment <- "Added version 2"
-    x
-  })() |>
+  synSetProperties(
+    version_label   = "2",
+    version_comment = "Added version 2"
+  ) |>
   synStore()
 ```
 


### PR DESCRIPTION
This is a duplicate PR of this: https://github.com/Sage-Bionetworks/synapser/pull/362  

I accidentally merged it to the wrong branch. 

# **Problem:**

The synapser pipe-based workflow had no ergonomic way to set entity properties for `synStore()` call. Users were forced to use an immediately-invoked lambda:

```
synGet("syn123") |>
  (\(x) { x$version_label <- "2"; x$version_comment <- "draft"; x })() |>
  synStore()
```

# **Solution:**

Added synSetProperties(), a pipe-friendly R helper that validates and sets one or more named properties on a Synapse entity before storing it:

```
synGet("syn123") |>
  synSetProperties(version_label = "2", version_comment = "draft") |>
  synStore()

```

# **Testing:**

Unit tests added in tests/testthat/test_synSetProperties.R.
Integration test is done in the newly updated Data Upload, Download, and Delete vignette. 